### PR TITLE
fixes #127

### DIFF
--- a/arch/templates/arch/hint_list.html
+++ b/arch/templates/arch/hint_list.html
@@ -56,7 +56,7 @@
     </p>
   {% endif %}
   <div class="text-center">
-    <a href="{% url "hint-create" problem.puid %}" class="btn btn-primary">Add hint</a>
+    <a href="{% url "hint-create" problem.puid %}" class="btn btn-secondary">Add hint</a>
   </div>
   <hr />
   <ul>


### PR DESCRIPTION
Changed class of link from "btn btn-primary" to "btn btn-secondary".

### Type of change

<!-- Check all that apply -->

- [ ] Enhancement
- [ ] Major Feature update
- [ ] Bug fixes
- [ ] Documentation
- [ ] Typos or copy edits
- [ ] Breaking Change

### Motivation

<!-- Describe what problem this PR is addressing -->

### Description

<!-- Details about what this PR does -->

### Additional information

<!-- Any other additional info -->
