### PR TITLE
Change the AoPS link

### DIFF
--- a/arch/templates/arch/hint_list.html
+++ b/arch/templates/arch/hint_list.html
@@ -15,7 +15,7 @@
   {% if problem.hyperlink %}
     <p class="text-center">
       <a class="btn btn-secondary" href="{{ problem.hyperlink }}">
-        <tt>{{ problem.hyperlink|truncatechars:"40" }}</tt>
+        <tt>Visit AoPS</tt>
       </a>
     </p>
   {% endif %}
@@ -33,13 +33,10 @@
     <p>
       Some of the hints may be pretty oblique
       or not apply to you.
-      Remember, you can always ask the OTIS Discord
+      Remember, you can always
+      <a href="https://discord.com/channels/740366393022742618/1019651152385679491">ask the OTIS Discord</a>
       or <a href="mailto:evan@evanchen.cc">email Evan (evan@evanchen.cc)</a>
       for more personalized help!
-    </p>
-    <p class="text-center">
-      <a href="https://discord.com/channels/740366393022742618/1019651152385679491"
-         class="btn btn-primary">Open #math-discuss</a>
     </p>
   {% else %}
     <p>
@@ -59,7 +56,7 @@
     </p>
   {% endif %}
   <div class="text-center">
-    <a href="{% url "hint-create" problem.puid %}" class="btn btn-success">➕ Add hint</a>
+    <a href="{% url "hint-create" problem.puid %}" class="btn btn-primary">Add hint</a>
   </div>
   <hr />
   <ul>


### PR DESCRIPTION
Changed the button which leads to the AoPS thread on the problem. In the past it included the entire link (it was shown) and this was ugly and long (leading the button to sometimes even jump off the page). Anyways the user has no use of seeing the link so why no change it to say "Visit AoPS"

Describe what kind of changes you made here:
small enhancement

If you're an OTIS student, include your OTIS-WEB username or student ID number
Lasitha Vishwajith Jayasinghe
