### PR TITLE
Truncate market prompts issue #117

### DIFF
--- a/markets/admin.py
+++ b/markets/admin.py
@@ -10,7 +10,7 @@ class MarketAdmin(admin.ModelAdmin):
     list_display = (
         'slug',
         'title',
-        'prompt',
+        'prompt_truncated',
         'start_date',
         'end_date',
         'semester',
@@ -25,6 +25,11 @@ class MarketAdmin(admin.ModelAdmin):
         'prompt',
     )
 
+    @admin.display(description='Prompt')
+    def prompt_truncated(self, obj):
+        NUM_CHAR = 200
+        text = obj.prompt
+        return text[:200] + ("..." if len(text) > 200 else "")
 
 @admin.register(Guess)
 class GuessAdmin(admin.ModelAdmin):

--- a/markets/admin.py
+++ b/markets/admin.py
@@ -26,10 +26,11 @@ class MarketAdmin(admin.ModelAdmin):
     )
 
     @admin.display(description='Prompt')
-    def prompt_truncated(self, obj):
+    def prompt_truncated(self, obj: Market) -> str:
         NUM_CHAR = 200
         text = obj.prompt
-        return text[:200] + ("..." if len(text) > 200 else "")
+        return text[:NUM_CHAR] + ("..." if len(text) > NUM_CHAR else "")
+
 
 @admin.register(Guess)
 class GuessAdmin(admin.ModelAdmin):


### PR DESCRIPTION
For #117, I made the market prompts in admin panel truncated if they were too long. I didn't use `@property`, because I didn't know how to change the name of the heading in the admin view if I did it that way.

otis id is 787