### PR TITLE
Grace Invoice Changes

### DIFF
--- a/dashboard/templates/dashboard/portal.html
+++ b/dashboard/templates/dashboard/portal.html
@@ -43,26 +43,39 @@
     </div>
   {% endif %}
   {% if student.enabled and not student.payment_status|divisibleby:"4" %}
-    <div class="alert {% if student.payment_status == 1 or student.payment_status == 5 %} alert-info {% elif student.payment_status == 2 or student.payment_status == 6 %} alert-warning {% elif student.payment_status == 3 or student.payment_status == 7 %} alert-danger {% endif %} ">
+    <div class="alert {% if student.payment_status == -3 or student.payment_status == 1 or student.payment_status == 5 %} alert-info {% elif student.payment_status == -2 or student.payment_status == 2 or student.payment_status == 6 %} alert-warning {% elif student.payment_status == -1 or student.payment_status == 3 or student.payment_status == 7 %} alert-danger {% endif %} ">
       <h1 class="alert-heading">
-        {% if student.payment_status == 1 or student.payment_status == 5 %}
+        {% if student.payment_status == -3 or student.payment_status == 1 or student.payment_status == 5 %}
           Payment reminder
-        {% elif student.payment_status == 2 or student.payment_status == 3 %}
+        {% elif student.payment_status == -2 or student.payment_status == 2 or student.payment_status == 6 %}
           Payment due
         {% else %}
           Payment overdue
         {% endif %}
       </h1>
-      {% if student.payment_status == 1 %}
-        As a quick reminder, the payment deadline
+
+      {% if student.payment_status == -3 %}
+        As a quick reminder, the grace deadline
+        {{ invoice.forgive_date|date }}
+        for full payment is coming soon.
+      {% elif student.payment_status == -2 %}
+        The grace payment deadline
+        {{ invoice.forgive_date|date }}
+        has passed, but your payment is incomplete.
+      {% elif student.payment_status == -1 %}
+        More than a week since the grace deadline
+        {{ invoice.forgive_date|date }}
+        has passed, but your payment is incomplete!
+      {% elif student.payment_status == 1 %}
+        As a quick reminder, the first payment deadline
         {{ semester.first_payment_deadline|date }}
         is coming soon.
       {% elif student.payment_status == 2 %}
-        The payment deadline
+        The first payment deadline
         {{ semester.first_payment_deadline|date }}
         has passed, but no payment was received.
       {% elif student.payment_status == 3 %}
-        More than a week since the deadline
+        More than a week since the first payment deadline
         {{ semester.first_payment_deadline|date }}
         has passed, but no payment is recorded.
       {% elif student.payment_status == 5 %}
@@ -72,11 +85,11 @@
       {% elif student.payment_status == 6 %}
         The payment deadline
         {{ semester.most_payment_deadline|date }}
-        has passed, but your payment is incomplete!
+        has passed, but your payment is incomplete.
       {% elif student.payment_status == 7 %}
         More than a week since the deadline
         {{ semester.most_payment_deadline|date }}
-        has passed, but your payment is incomplete.
+        has passed, but your payment is incomplete!
       {% endif %}
       <a href="{% url 'invoice' student.pk %}" class="alert-link">Link to invoice.</a>
     </div>

--- a/roster/admin.py
+++ b/roster/admin.py
@@ -348,7 +348,9 @@ def build_students(queryset: QuerySet[StudentRegistration]) -> int:
             if first_payment_deadline is not None and first_payment_deadline <= (
                 grace_deadline := timezone.now() + timedelta(days=7)
             ):
-                invoice.forgive_date = max(grace_deadline, student.semester.most_payment_deadline)
+                invoice.forgive_date = max(
+                    grace_deadline, student.semester.most_payment_deadline
+                )
             invoices_to_create.append(invoice)
         Invoice.objects.bulk_create(invoices_to_create)
     return count

--- a/roster/admin.py
+++ b/roster/admin.py
@@ -348,7 +348,7 @@ def build_students(queryset: QuerySet[StudentRegistration]) -> int:
             if first_payment_deadline is not None and first_payment_deadline <= (
                 grace_deadline := timezone.now() + timedelta(days=7)
             ):
-                invoice.forgive_date = grace_deadline
+                invoice.forgive_date = max(grace_deadline, student.semester.most_payment_deadline)
             invoices_to_create.append(invoice)
         Invoice.objects.bulk_create(invoices_to_create)
     return count

--- a/roster/models.py
+++ b/roster/models.py
@@ -14,7 +14,7 @@ from django.db import models
 from django.db.models import Count, Q
 from django.db.models.query import QuerySet
 from django.urls import reverse
-from django.utils.timezone import localtime, now
+from django.utils.timezone import localtime
 from sql_util.aggregates import Exists, SubqueryAggregate
 
 from .country_abbrevs import COUNTRY_CHOICES

--- a/roster/templates/roster/invoice.html
+++ b/roster/templates/roster/invoice.html
@@ -58,7 +58,7 @@
     </p>
     
     {% if invoice.forgive_date %}
-      <p>As a reminder, the grace payment deadlines are:</p>
+      <p>As a reminder, the grace payment deadline are:</p>
       <ul>
         {% if invoice.forgive_date %}<li>{{ invoice.forgive_date|date }}</li>{% endif %}
       </ul>

--- a/roster/templates/roster/invoice.html
+++ b/roster/templates/roster/invoice.html
@@ -2,22 +2,22 @@
 {% load static %}
 {% load otis_extras %}
 {% block layout-content %}
-  {% if student.is_payment_locked %}
+  {% if student.is_delinquent %}
     <div class="alert alert-danger" role="alert">
       <h2 class="alert-heading">Overdue payment</h2>
       Your current payment is more than one week overdue.
       Please remit payment to continue using OTIS-WEB.
     </div>
   {% endif %}
-  {% if not invoice.student.semester.active %}
+  {% if not student.semester.active %}
     <div class="alert alert-danger" role="alert">
       <h2 class="alert-title">You are viewing the invoice for a past year!</h2>
       This is the invoice for
-      <b>{{ invoice.student.semester.years }}</b>.
+      <b>{{ student.semester.years }}</b>.
       If you are trying to pay for the current year then you should
       <a class="alert-link" href="{% url "invoice" %}">go to the current year's invoice</a>.
     </div>
-  {% elif not invoice.student.semester.show_invoices %}
+  {% elif not student.semester.show_invoices %}
     <div class="alert alert-info" role="alert">
       <h2 class="alert-title">Preliminary invoice only</h2>
       Invoices are not ready for distribution yet.
@@ -35,7 +35,7 @@
     Here is a link to a payment page that works without login
     (so obviously, only send this to people you trust).
     <center>
-      {% if invoice.student.semester.active %}
+      {% if student.semester.active %}
         <a href="{% url "payments-invoice" student.pk checksum %}"
            class="btn btn-success col-xs-12 col-sm-6">
           Make payment via card
@@ -56,13 +56,20 @@
       Please contact me if you think there are any errors
       (I make mistakes every year!).
     </p>
-    {% if student.semester.first_payment_deadline or student.semester.most_payment_deadline %}
+    
+    {% if invoice.forgive_date %}
+      <p>As a reminder, the grace payment deadlines are:</p>
+      <ul>
+        {% if invoice.forgive_date %}<li>{{ invoice.forgive_date|date }}</li>{% endif %}
+      </ul>
+    {% elif student.semester.first_payment_deadline or student.semester.most_payment_deadline %}
       <p>As a reminder, the payment deadlines are:</p>
       <ul>
         {% if student.semester.first_payment_deadline %}<li>{{ student.semester.first_payment_deadline|date }}</li>{% endif %}
         {% if student.semester.most_payment_deadline %}<li>{{ student.semester.most_payment_deadline|date }}</li>{% endif %}
       </ul>
     {% endif %}
+    
     <p>
       If you have an assistant instructor,
       that payment should be done separately.

--- a/roster/tests.py
+++ b/roster/tests.py
@@ -153,7 +153,7 @@ class RosterTest(EvanTestCase):
         with freeze_time("2023-02-15", tz_offset=0):
             self.assertEqual(alice.payment_status, 7)
             self.assertTrue(alice.is_delinquent)
-        
+
         # Now suppose Alice makes the last payment
         invoice.total_paid = 480
         invoice.save()

--- a/roster/tests.py
+++ b/roster/tests.py
@@ -117,26 +117,15 @@ class RosterTest(EvanTestCase):
         self.assertEqual(invoice.total_owed, 480)
         with freeze_time("2022-09-05", tz_offset=0):
             self.assertEqual(alice.payment_status, 4)
-            self.assertFalse(alice.is_payment_locked)
             self.assertFalse(alice.is_delinquent)
         with freeze_time("2022-09-17", tz_offset=0):
             self.assertEqual(alice.payment_status, 1)
-            self.assertFalse(alice.is_payment_locked)
             self.assertFalse(alice.is_delinquent)
         with freeze_time("2022-09-25", tz_offset=0):
             self.assertEqual(alice.payment_status, 2)
-            self.assertFalse(alice.is_payment_locked)
             self.assertFalse(alice.is_delinquent)
         with freeze_time("2022-10-15", tz_offset=0):
             self.assertEqual(alice.payment_status, 3)
-            self.assertTrue(alice.is_payment_locked)
-            self.assertTrue(alice.is_delinquent)
-            invoice.forgive_date = timezone.datetime(2022, 10, 31, tzinfo=timezone.utc)
-            invoice.save()
-            self.assertFalse(alice.is_delinquent)
-        with freeze_time("2022-11-15", tz_offset=0):
-            self.assertEqual(alice.payment_status, 3)
-            self.assertTrue(alice.is_payment_locked)
             self.assertTrue(alice.is_delinquent)
 
         # Now suppose Alice makes the first payment
@@ -145,48 +134,60 @@ class RosterTest(EvanTestCase):
         self.assertEqual(invoice.total_owed, 240)
         with freeze_time("2022-09-05", tz_offset=0):
             self.assertEqual(alice.payment_status, 4)
-            self.assertFalse(alice.is_payment_locked)
             self.assertFalse(alice.is_delinquent)
         with freeze_time("2022-09-17", tz_offset=0):
             self.assertEqual(alice.payment_status, 4)
-            self.assertFalse(alice.is_payment_locked)
             self.assertFalse(alice.is_delinquent)
         with freeze_time("2022-09-25", tz_offset=0):
             self.assertEqual(alice.payment_status, 4)
-            self.assertFalse(alice.is_payment_locked)
             self.assertFalse(alice.is_delinquent)
         with freeze_time("2022-10-15", tz_offset=0):
             self.assertEqual(alice.payment_status, 4)
-            self.assertFalse(alice.is_payment_locked)
             self.assertFalse(alice.is_delinquent)
         with freeze_time("2023-01-17", tz_offset=0):
             self.assertEqual(alice.payment_status, 5)
-            self.assertFalse(alice.is_payment_locked)
             self.assertFalse(alice.is_delinquent)
         with freeze_time("2023-01-25", tz_offset=0):
             self.assertEqual(alice.payment_status, 6)
-            self.assertFalse(alice.is_payment_locked)
             self.assertFalse(alice.is_delinquent)
         with freeze_time("2023-02-15", tz_offset=0):
             self.assertEqual(alice.payment_status, 7)
-            self.assertTrue(alice.is_payment_locked)
             self.assertTrue(alice.is_delinquent)
-            invoice.forgive_date = timezone.datetime(2023, 2, 28, tzinfo=timezone.utc)
-            invoice.save()
-            self.assertFalse(alice.is_delinquent)
-        with freeze_time("2023-06-05", tz_offset=0):
-            self.assertEqual(alice.payment_status, 7)
-            self.assertTrue(alice.is_payment_locked)
-            self.assertTrue(alice.is_delinquent)
-
+        
         # Now suppose Alice makes the last payment
         invoice.total_paid = 480
         invoice.save()
         self.assertEqual(invoice.total_owed, 0)
         with freeze_time("2023-02-15", tz_offset=0):
             self.assertEqual(alice.payment_status, 0)
-            self.assertFalse(alice.is_payment_locked)
             self.assertFalse(alice.is_delinquent)
+
+        # Bob is a late student and has a grace deadline
+        bob: Student = StudentFactory.create(semester=semester)
+
+        self.assertEqual(bob.payment_status, 0)  # because no invoice exists
+        invoice: Invoice = InvoiceFactory.create(
+            student=bob,
+            preps_taught=1,
+        )
+        invoice.forgive_date = timezone.datetime(2023, 2, 28, tzinfo=timezone.utc)
+        invoice.save()
+
+        with freeze_time("2023-01-25", tz_offset=0):
+            self.assertEqual(bob.payment_status, 4)
+            self.assertFalse(bob.is_delinquent)
+        with freeze_time("2023-02-15", tz_offset=0):
+            self.assertEqual(bob.payment_status, 4)
+            self.assertFalse(bob.is_delinquent)
+        with freeze_time("2023-02-22", tz_offset=0):
+            self.assertEqual(bob.payment_status, -3)
+            self.assertFalse(bob.is_delinquent)
+        with freeze_time("2023-03-01", tz_offset=0):
+            self.assertEqual(bob.payment_status, -2)
+            self.assertFalse(bob.is_delinquent)
+        with freeze_time("2023-03-10", tz_offset=0):
+            self.assertEqual(bob.payment_status, -1)
+            self.assertTrue(bob.is_delinquent)
 
     def test_master_schedule(self) -> None:
         alice: Student = StudentFactory.create(


### PR DESCRIPTION
Actually deals with #146 I think.

Render warnings and info for grace deadline as appropriate. This also merges `is_delinquint` and `is_payment_locked` using `-3`, `-2`, `-1` respectively as returned statuses.

![image](https://user-images.githubusercontent.com/58920010/213022182-490a1906-f880-419b-bf99-61361d7f4fbd.png)
![image](https://user-images.githubusercontent.com/58920010/213022208-f480bd77-5916-4ef1-a9da-f02f3ff9ef09.png)

Other changes is setting the grace deadline as the maximum of `most_payment_deadline` and seven days from now, in the rare case that someone is approved after `first_payment_deadline` but before `most_payment_deadline`

Some changes to the words themself have occurred, override as necessary.

ID: 903