### PR TITLE
Suggestion Deletion

### DIFF
--- a/dashboard/tests.py
+++ b/dashboard/tests.py
@@ -430,7 +430,7 @@ class TestPSet(EvanTestCase):
 
         upload = UploadedFile.objects.filter(benefactor=alice, unit=unit).first()
 
-        assert upload != None
+        assert upload is not None
 
         self.assertTrue(upload.unit == unit)
         self.assertTrue(upload.owner == alice.user)
@@ -449,7 +449,7 @@ class TestPSet(EvanTestCase):
 
         upload = UploadedFile.objects.filter(pk=pk).first()
 
-        assert upload != None
+        assert upload is not None
 
         self.assertTrue(upload.description == "bark")
 

--- a/dashboard/tests.py
+++ b/dashboard/tests.py
@@ -430,6 +430,8 @@ class TestPSet(EvanTestCase):
 
         upload = UploadedFile.objects.filter(benefactor=alice, unit=unit).first()
 
+        assert upload != None
+
         self.assertTrue(upload.unit == unit)
         self.assertTrue(upload.owner == alice.user)
 
@@ -446,6 +448,8 @@ class TestPSet(EvanTestCase):
         )
 
         upload = UploadedFile.objects.filter(pk=pk).first()
+
+        assert upload != None
 
         self.assertTrue(upload.description == "bark")
 

--- a/suggestions/models.py
+++ b/suggestions/models.py
@@ -62,7 +62,7 @@ class ProblemSuggestion(models.Model):
         db_table = "dashboard_problemsuggestion"  # historical babbage
 
     def __str__(self) -> str:
-        return f"{self.user.username} suggested {self.source} for {self.unit.group}"
+        return self.description
 
     def get_absolute_url(self) -> str:
         return reverse("suggest-update", args=(self.pk,))

--- a/suggestions/templates/suggestions/problemsuggestion_confirm_delete.html
+++ b/suggestions/templates/suggestions/problemsuggestion_confirm_delete.html
@@ -1,0 +1,7 @@
+{% extends "layout.html" %}
+{% block title %}
+  Delete Suggestion
+{% endblock title %}
+{% block layout-content %}
+  {% include "generic_delete.html" %}
+{% endblock layout-content %}

--- a/suggestions/templates/suggestions/problemsuggestion_confirm_delete.html
+++ b/suggestions/templates/suggestions/problemsuggestion_confirm_delete.html
@@ -9,6 +9,6 @@
   <ul>
     <li>Source: {{ suggestion.source }}</li>
     <li>Unit: {{ suggestion.unit.group.name }}<sup>{{ suggestion.unit.code }}</sup></li>
-    <li>Hyperlink: {{ suggestion.hyperlink }}</sup></li>
+    <li>Hyperlink: {{ suggestion.hyperlink }}</li>
   </ul>
 {% endblock layout-content %}

--- a/suggestions/templates/suggestions/problemsuggestion_confirm_delete.html
+++ b/suggestions/templates/suggestions/problemsuggestion_confirm_delete.html
@@ -4,4 +4,11 @@
 {% endblock title %}
 {% block layout-content %}
   {% include "generic_delete.html" %}
+  <hr />
+  <a href="{{ suggestion.get_absolute_url }}">&lt;&lt; Go back to suggestion</a>
+  <ul>
+    <li>Source: {{ suggestion.source }}</li>
+    <li>Unit: {{ suggestion.unit.group.name }}<sup>{{ suggestion.unit.code }}</sup></li>
+    <li>Hyperlink: {{ suggestion.hyperlink }}</sup></li>
+  </ul>
 {% endblock layout-content %}

--- a/suggestions/templates/suggestions/problemsuggestion_form.html
+++ b/suggestions/templates/suggestions/problemsuggestion_form.html
@@ -120,8 +120,8 @@
         <td>
           <button id="render-toggle" class="btn btn-info">Disable instant TeX</button>
           {% if pk %}
-            <button id="delete" class="btn btn-warning" style="margin-left: 50px">Delete Suggestion
-            </button>
+            <a id="delete" href="{% url 'suggest-delete' pk %}" class="btn btn-link btn-warning" style="margin-left: 50px">Delete Suggestion
+            </a>
           {% endif %}
       </tr>
     </table>
@@ -227,12 +227,6 @@
             render_solution();
         });
 
-        {% if pk %}
-          $("#delete").click(function(e) {
-            e.preventDefault();
-            window.location = '{% url 'suggest-delete' pk %}';
-          })
-        {% endif %}
 
         function checkLineLength(s) {
             lines = s.split("\n");
@@ -245,7 +239,6 @@
             return true;
         }
         
-
         $("#id_statement").on("input", (e) => {
             $("#statement_warning").toggle(!checkLineLength(e.target.value));
             if (!autorender_enabled || !render_enabled) return;

--- a/suggestions/templates/suggestions/problemsuggestion_form.html
+++ b/suggestions/templates/suggestions/problemsuggestion_form.html
@@ -123,6 +123,7 @@
             <a id="delete" href="{% url 'suggest-delete' pk %}" class="btn btn-link btn-warning" style="margin-left: 50px">Delete Suggestion
             </a>
           {% endif %}
+        </td>
       </tr>
     </table>
     <h2 id="instructions">Submission requirements</h2>

--- a/suggestions/templates/suggestions/problemsuggestion_form.html
+++ b/suggestions/templates/suggestions/problemsuggestion_form.html
@@ -119,7 +119,10 @@
         </td>
         <td>
           <button id="render-toggle" class="btn btn-info">Disable instant TeX</button>
-        </td>
+          {% if pk %}
+            <button id="delete" class="btn btn-warning" style="margin-left: 50px">Delete Suggestion
+            </button>
+          {% endif %}
       </tr>
     </table>
     <h2 id="instructions">Submission requirements</h2>
@@ -224,6 +227,13 @@
             render_solution();
         });
 
+        {% if pk %}
+          $("#delete").click(function(e) {
+            e.preventDefault();
+            window.location = '{% url 'suggest-delete' pk %}';
+          })
+        {% endif %}
+
         function checkLineLength(s) {
             lines = s.split("\n");
             for (let i in lines) {
@@ -234,6 +244,7 @@
             }
             return true;
         }
+        
 
         $("#id_statement").on("input", (e) => {
             $("#statement_warning").toggle(!checkLineLength(e.target.value));

--- a/suggestions/urls.py
+++ b/suggestions/urls.py
@@ -10,7 +10,11 @@ urlpatterns = [
         name="suggest-new",
     ),
     path(r"<int:pk>/", views.ProblemSuggestionUpdate.as_view(), name="suggest-update"),
-    path(r"delete/<int:pk>/", views.ProblemSuggestionDelete.as_view(), name="suggest-delete"),
+    path(
+        r"delete/<int:pk>/",
+        views.ProblemSuggestionDelete.as_view(),
+        name="suggest-delete",
+    ),
     path(r"list/", views.ProblemSuggestionList.as_view(), name="suggest-list"),
     path(r"queue/", views.SuggestionQueueList.as_view(), name="suggest-queue-listing"),
 ]

--- a/suggestions/urls.py
+++ b/suggestions/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
         name="suggest-new",
     ),
     path(r"<int:pk>/", views.ProblemSuggestionUpdate.as_view(), name="suggest-update"),
+    path(r"delete/<int:pk>/", views.ProblemSuggestionDelete.as_view(), name="suggest-delete"),
     path(r"list/", views.ProblemSuggestionList.as_view(), name="suggest-list"),
     path(r"queue/", views.SuggestionQueueList.as_view(), name="suggest-queue-listing"),
 ]

--- a/suggestions/views.py
+++ b/suggestions/views.py
@@ -102,6 +102,8 @@ class ProblemSuggestionDelete(LoginRequiredMixin, DeleteView):
     model = ProblemSuggestion
     success_url = reverse_lazy("suggest-new")
 
+    context_object_name = "suggestion"
+
     def get_object(self, *args: Any, **kwargs: Any) -> ProblemSuggestion:
         obj = super().get_object(*args, **kwargs)
         assert isinstance(self.request.user, User)

--- a/suggestions/views.py
+++ b/suggestions/views.py
@@ -93,7 +93,7 @@ class ProblemSuggestionUpdate(
             raise PermissionDenied("Please log in.")
         if not (self.request.user.is_staff or self.request.user == self.object.user):
             raise PermissionDenied("Logged-in user cannot view this suggestion")
-        
+
         context["pk"] = self.kwargs.get("pk", None)
         return context
         return context

--- a/suggestions/views.py
+++ b/suggestions/views.py
@@ -96,7 +96,6 @@ class ProblemSuggestionUpdate(
 
         context["pk"] = self.kwargs.get("pk", None)
         return context
-        return context
 
 
 class ProblemSuggestionDelete(LoginRequiredMixin, DeleteView):

--- a/suggestions/views.py
+++ b/suggestions/views.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 from braces.views import LoginRequiredMixin
 from core.models import Unit
@@ -9,7 +9,8 @@ from django.db.models.query import QuerySet
 from django.forms.models import BaseModelForm
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
-from django.views.generic.edit import CreateView, UpdateView
+from django.urls.base import reverse_lazy
+from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.views.generic.list import ListView
 
 from .models import ProblemSuggestion
@@ -92,7 +93,22 @@ class ProblemSuggestionUpdate(
             raise PermissionDenied("Please log in.")
         if not (self.request.user.is_staff or self.request.user == self.object.user):
             raise PermissionDenied("Logged-in user cannot view this suggestion")
+        
+        context["pk"] = self.kwargs.get("pk", None)
         return context
+        return context
+
+
+class ProblemSuggestionDelete(LoginRequiredMixin, DeleteView):
+    model = ProblemSuggestion
+    success_url = reverse_lazy("suggest-new")
+
+    def get_object(self, *args: Any, **kwargs: Any) -> ProblemSuggestion:
+        obj = super().get_object(*args, **kwargs)
+        assert isinstance(self.request.user, User)
+        if obj.user != self.request.user and not self.request.user.is_staff:
+            raise PermissionDenied("Not authorized to delete this file")
+        return obj
 
 
 class ProblemSuggestionList(LoginRequiredMixin, ListView[ProblemSuggestion]):

--- a/suggestions/views.py
+++ b/suggestions/views.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from braces.views import LoginRequiredMixin
 from core.models import Unit


### PR DESCRIPTION
Fixes #170 

This adds a way to delete created suggestions with a button 
![image](https://user-images.githubusercontent.com/58920010/215959813-632346f6-0112-4615-8c05-a80da409fc98.png)

However, do note that certain parts of this pr are very scuffed, and complain for a better implementation if glaring enough
- Redirecting with the button is handled by js
- The button is placed in the same table entry with the disable tex button, with a hackily added `margin-left` to add some distance between the two of them