### PR TITLE
Diamond in Wiki Based off pk

### DIFF
--- a/wikihaxx/mdx/otis.py
+++ b/wikihaxx/mdx/otis.py
@@ -42,7 +42,7 @@ class OTISPreprocessor(markdown.preprocessors.Preprocessor):
 
                 if tag_name == "diamond":
                     try:
-                        diamond = Achievement.objects.get(code__iexact=tag_arg)
+                        diamond = Achievement.objects.get(pk=tag_arg)
                     except Achievement.DoesNotExist:
                         table_output.append(
                             '<tr class="danger"><th>Code</th><td>INVALID</td></tr>'

--- a/wikihaxx/mdx/otis.py
+++ b/wikihaxx/mdx/otis.py
@@ -45,33 +45,42 @@ class OTISPreprocessor(markdown.preprocessors.Preprocessor):
                         diamond = Achievement.objects.get(pk=tag_arg)
                     except Achievement.DoesNotExist:
                         table_output.append(
-                            '<tr class="danger"><th>Code</th><td>INVALID</td></tr>'
+                            '<tr class="danger"><th>Diamond</th><td>INVALID</td></tr>'
                         )
                     else:
-                        if diamond.image:
-                            art_url = diamond.image.url
-                            output.append(
-                                f'<div class="W-100 text-center"><a href="{art_url}">'
-                                f'<img class="w-100" src="{art_url}" /></a></div>'
-                            )
-                        table_output.append(
-                            f"<tr><th>Name</th><td>{diamond.name}</td></tr>"
-                        )
-                        table_output.append(
-                            f"<tr><th>Value</th><td>{diamond.diamonds}◆</td></tr>"
-                        )
                         num_found = (
                             AchievementUnlock.objects.filter(
                                 achievement=diamond
                             ).count()
                             or 0
                         )
-                        table_output.append(
-                            f"<tr><th>Found by</th><td>{num_found}</td></tr>"
-                        )
-                        table_output.append(
-                            f"<tr><th>Description</th><td>{diamond.description}</td></tr>"
-                        )
+
+                        # check to make sure is not user diamond and
+
+                        if diamond.creator is None and num_found > 0:
+                            if diamond.image:
+                                art_url = diamond.image.url
+                                output.append(
+                                    f'<div class="W-100 text-center"><a href="{art_url}">'
+                                    f'<img class="w-100" src="{art_url}" /></a></div>'
+                                )
+                            table_output.append(
+                                f"<tr><th>Name</th><td>{diamond.name}</td></tr>"
+                            )
+                            table_output.append(
+                                f"<tr><th>Value</th><td>{diamond.diamonds}◆</td></tr>"
+                            )
+                            table_output.append(
+                                f"<tr><th>Found by</th><td>{num_found}</td></tr>"
+                            )
+                            table_output.append(
+                                f"<tr><th>Description</th><td>{diamond.description}</td></tr>"
+                            )
+                        else:
+                            table_output.append(
+                                '<tr class="danger"><th>Diamond</th><td>NOT ALLOWED</td></tr>'
+                            )
+
                 elif tag_name == "unit":
                     try:
                         unitgroup = UnitGroup.objects.get(

--- a/wikihaxx/mdx/otis.py
+++ b/wikihaxx/mdx/otis.py
@@ -55,8 +55,6 @@ class OTISPreprocessor(markdown.preprocessors.Preprocessor):
                             or 0
                         )
 
-                        # check to make sure is not user diamond and
-
                         if diamond.creator is None and num_found > 0:
                             if diamond.image:
                                 art_url = diamond.image.url

--- a/wikihaxx/templates/wikihaxx/sidebar.html
+++ b/wikihaxx/templates/wikihaxx/sidebar.html
@@ -9,7 +9,7 @@
     (The slug is the natural part of the unit's filename, e.g. "equality".)
   </li>
   <li>
-    Use the header <code>[diamond HEX][/diamond]</code>
+    Use the header <code>[diamond PK][/diamond]</code>
     for pages about diamonds.
   </li>
   <li>


### PR DESCRIPTION
A few reasons for this:
- You can't make a wiki page currently with a diamond without leaking it
- The wiki diamond isn't special since there's also a wikipage for Start Here as a result
- More diamond pages would be cool

![image](https://user-images.githubusercontent.com/58920010/235237247-17ad7168-beeb-46df-b2ff-685f300ca51e.png)
![image](https://user-images.githubusercontent.com/58920010/235237258-39aa38c4-396a-4a7c-9cea-73635d6d323c.png)

The tag is only expanded to show information if the diamond is not user made and at least one person has found the diamond.