### PR TITLE
Fix Petition Regression

### DIFF
--- a/roster/views.py
+++ b/roster/views.py
@@ -319,7 +319,7 @@ def handle_inquiry(request: AuthHttpRequest, inquiry: UnitInquiry, student: Stud
         return
 
     # auto-acceptance criteria
-    auto_accept_criteria = num_past_unlock_inquiries <= 6 and unlocked_count < 9
+    auto_accept_criteria = num_past_unlock_inquiries <= 6 and unlocked_count <= 9
     # auto dropping locked units
     auto_accept_criteria |= (
         inquiry.action_type == "INQ_ACT_DROP"


### PR DESCRIPTION
`unlocked_count` is one larger than expected since I think my old commit reordered the code. xd

![image](https://github.com/vEnhance/otis-web/assets/58920010/c33a216f-7635-42a5-929f-917ddf4294aa)
