### PR TITLE
Fix non_field_errors

### DIFF
--- a/arch/views.py
+++ b/arch/views.py
@@ -196,6 +196,18 @@ class HintCreate(
         initial = initial.copy()
         initial["problem"] = Problem.objects.get(puid=self.kwargs["puid"])
         return initial
+    
+    def form_invalid(self, form):
+        logger.log(
+            ACTION_LOG_LEVEL,
+            form)
+        logger.log(
+            ACTION_LOG_LEVEL,
+            form.non_field_errors()
+        )
+
+        return super().form_invalid(form)
+
 
 
 class HintDelete(HintObjectView, VerifiedRequiredMixin, RevisionMixin, DeleteView):

--- a/arch/views.py
+++ b/arch/views.py
@@ -196,18 +196,6 @@ class HintCreate(
         initial = initial.copy()
         initial["problem"] = Problem.objects.get(puid=self.kwargs["puid"])
         return initial
-    
-    def form_invalid(self, form):
-        logger.log(
-            ACTION_LOG_LEVEL,
-            form)
-        logger.log(
-            ACTION_LOG_LEVEL,
-            form.non_field_errors()
-        )
-
-        return super().form_invalid(form)
-
 
 
 class HintDelete(HintObjectView, VerifiedRequiredMixin, RevisionMixin, DeleteView):

--- a/otisweb/templates/generic_form.html
+++ b/otisweb/templates/generic_form.html
@@ -8,27 +8,30 @@
     <div class="alert alert-danger" role="alert">
       <strong>{{ "Error"|title }}</strong>
       <ul>
-        {% for error in form.non_field_errors %}<li>{{ error }}{% endfor %}
-      </ul>
-    </div>
-  {% elif form.errors %}
-    <div class="alert alert-danger" role="alert">
-      {% for err,val in form.errors.items %}
-        {% if err == "content" and "This field is required." in val %}
-          <strong>File upload</strong>
-          <ul>
-            <li>
-              There was an error with your file upload.
-              Please make sure that you file submission and is no larger than 10 MB.
-            </li>
-          </ul>
-        {% else %}
-          <strong>{{ err|title }}</strong> {{ val }}
-        {% endif %}
-      {% endfor %}
-    </div>
-  {% endif %}
-  {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
-  {% for field in form.visible_fields %}{{ field|as_crispy_field }}{% endfor %}
-  <button type="submit" class="btn {{ btn_class|default:"btn-success" }}">{{ submit_name|default:"Submit" }}</button>
-</form>
+        {% for error in form.non_field_errors %}
+          <li>
+            {{ error }}
+          {% endfor %}
+        </ul>
+      </div>
+    {% elif form.errors %}
+      <div class="alert alert-danger" role="alert">
+        {% for err,val in form.errors.items %}
+          {% if err == "content" and "This field is required." in val %}
+            <strong>File upload</strong>
+            <ul>
+              <li>
+                There was an error with your file upload.
+                Please make sure that you file submission and is no larger than 10 MB.
+              </li>
+            </ul>
+          {% else %}
+            <strong>{{ err|title }}</strong> {{ val }}
+          {% endif %}
+        {% endfor %}
+      </div>
+    {% endif %}
+    {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
+    {% for field in form.visible_fields %}{{ field|as_crispy_field }}{% endfor %}
+    <button type="submit" class="btn {{ btn_class|default:"btn-success" }}">{{ submit_name|default:"Submit" }}</button>
+  </form>

--- a/otisweb/templates/generic_form.html
+++ b/otisweb/templates/generic_form.html
@@ -6,32 +6,29 @@
   {% csrf_token %}
   {% if form.non_field_errors %}
     <div class="alert alert-danger" role="alert">
-      <strong>{{ "Error"|title }}</strong>
+      <strong>Errors</strong>
       <ul>
-        {% for error in form.non_field_errors %}
-          <li>
-            {{ error }}
-          {% endfor %}
-        </ul>
-      </div>
-    {% elif form.errors %}
-      <div class="alert alert-danger" role="alert">
-        {% for err,val in form.errors.items %}
-          {% if err == "content" and "This field is required." in val %}
-            <strong>File upload</strong>
-            <ul>
-              <li>
-                There was an error with your file upload.
-                Please make sure that you file submission and is no larger than 10 MB.
-              </li>
-            </ul>
-          {% else %}
-            <strong>{{ err|title }}</strong> {{ val }}
-          {% endif %}
-        {% endfor %}
-      </div>
-    {% endif %}
-    {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
-    {% for field in form.visible_fields %}{{ field|as_crispy_field }}{% endfor %}
-    <button type="submit" class="btn {{ btn_class|default:"btn-success" }}">{{ submit_name|default:"Submit" }}</button>
-  </form>
+        {% for err in form.non_field_errors %}<li>{{ err }}</li>{% endfor %}
+      </ul>
+    </div>
+  {% elif form.errors %}
+    <div class="alert alert-danger" role="alert">
+      {% for err,val in form.errors.items %}
+        {% if err == "content" and "This field is required." in val %}
+          <strong>File upload</strong>
+          <ul>
+            <li>
+              There was an error with your file upload.
+              Please make sure that you file submission and is no larger than 10 MB.
+            </li>
+          </ul>
+        {% else %}
+          <strong>{{ err|title }}</strong> {{ val }}
+        {% endif %}
+      {% endfor %}
+    </div>
+  {% endif %}
+  {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
+  {% for field in form.visible_fields %}{{ field|as_crispy_field }}{% endfor %}
+  <button type="submit" class="btn {{ btn_class|default:"btn-success" }}">{{ submit_name|default:"Submit" }}</button>
+</form>

--- a/otisweb/templates/generic_form.html
+++ b/otisweb/templates/generic_form.html
@@ -6,8 +6,9 @@
   {% csrf_token %}
   {% if form.non_field_errors %}
     <div class="alert alert-danger" role="alert">
+      <strong>{{ "Error"|title }}</strong>
       <ul>
-        {% for err,val in form.non_field_errors.items %}<strong>{{ err|title }}</strong> {{ val }}{% endfor %}
+        {% for error in form.non_field_errors %}<li>{{ error }}{% endfor %}
       </ul>
     </div>
   {% elif form.errors %}


### PR DESCRIPTION
Fixes #278. Does some hacky things to get non_field_errors to look similar. Issue here was that non_field_errors isn't a dictionary.

![image](https://github.com/vEnhance/otis-web/assets/58920010/b10b7016-ce9d-42b3-b906-2c49c20aa3cb)
