### PR TITLE
Simpler invite links

### DIFF
--- a/tubes/templates/tubes/tube_list.html
+++ b/tubes/templates/tubes/tube_list.html
@@ -15,7 +15,10 @@
     {% endfor %}
   </ul>
   <h2>Instructions</h2>
-  <p>After joining above, you should be able to submit problems and testsolve proposals.</p>
+  <p>
+    Click on the link above to access the problem proposals on Probase.
+    After joining, you can submit problems and participate in testsolving.
+  </p>
   <h3>Proposing</h3>
   <ul>
     <li>Use "Add Problem" once you're in the Probase collection.</li>


### PR DESCRIPTION
This way, there's only one link to click. Less chance for students to accidentally mess up.

I also made the instructions clearer.

<img width="607" alt="image" src="https://github.com/vEnhance/otis-web/assets/26558499/5f82fd84-71cd-4d3c-b548-54e85e88d8ec">
