### PR TITLE
Catalog patch - fix 500 error

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from .models import UnitGroup
 
 
-class FilterForm(forms.Form):
+class CatalogFilterForm(forms.Form):
     difficulty = forms.MultipleChoiceField(
         choices=[("B", "B"), ("D", "D"), ("Z", "Z")],
         widget=forms.CheckboxSelectMultiple(attrs={"class": "filter-form"}),

--- a/core/templates/core/unit_list.html
+++ b/core/templates/core/unit_list.html
@@ -62,7 +62,7 @@
             <div class="col-9">
               <h4>
                 {% if units.0.has_pset_for_any_unit %}
-                  <a href="{% url "wiki-unitgroup" unitgroup.pk %}"><span class="text-success">{{ unit.code }}{{ unitgroup.name }}</span></a>
+                  <a href="{% url "wiki-unitgroup" unitgroup.pk %}"><span class="text-success">{{ unitgroup.name }}</span></a>
                 {% else %}
                   <a href="{% url "wiki-unitgroup" unitgroup.pk %}">{{ unitgroup.name }}</a>
                 {% endif %}

--- a/core/tests.py
+++ b/core/tests.py
@@ -21,6 +21,7 @@ class TestCore(EvanTestCase):
         self.assertGetBecomesLoginRedirect("view-problems", 10)
         self.assertGetBecomesLoginRedirect("view-solutions", 10)
         self.assertGetBecomesLoginRedirect("view-tex", 10)
+        self.assertGetBecomesLoginRedirect("catalog")
 
     @override_settings(TESTING_NEEDS_MOCK_MEDIA=True)
     def test_alice_core_views(self):
@@ -71,6 +72,7 @@ class TestCore(EvanTestCase):
         self.assertGet30X("admin-unit-list")
 
     def test_hidden(self):
+        self.login(UserFactory.create())
         UnitFactory.create(group__name="VisibleUnit", group__hidden=False)
         UnitFactory.create(group__name="HiddenUnit", group__hidden=True)
         resp = self.assertGet20X("catalog")
@@ -185,7 +187,6 @@ class TestCatalog(EvanTestCase):
         Logged in user without active student account
         previously recieved a 500 error when fitering by status
         """
-        user = UserFactory.create()
-        self.login(user)
+        self.login(UserFactory.create())
         self.assertCatalogEmpty({"status": "unlocked"})
         self.assertCatalogEmpty({"status": "locked"})

--- a/core/tests.py
+++ b/core/tests.py
@@ -113,6 +113,9 @@ class TestCatalog(EvanTestCase):
         self.assertEqual(unit_codes, expected_codes)
         return resp
 
+    def assertCatalogEmpty(self, query_params: dict[str, Any]):
+        return self.assertCatalogEqual(query_params, [])
+
     def test_catalog_search(self):
         self.assertCatalogEqual({"q": "UMS"}, ["DAX", "ZAX"])
 
@@ -176,3 +179,13 @@ class TestCatalog(EvanTestCase):
             {"status": ["completed", "locked"], "group_by_category": True},
             ["ZAW", "BMW"],
         )
+
+    def test_inactive_student(self):
+        """
+        Logged in user without active student account
+        previously recieved a 500 error when fitering by status
+        """
+        user = UserFactory.create()
+        self.login(user)
+        self.assertCatalogEmpty({"status": "unlocked"})
+        self.assertCatalogEmpty({"status": "locked"})

--- a/core/tests.py
+++ b/core/tests.py
@@ -185,7 +185,7 @@ class TestCatalog(EvanTestCase):
     def test_inactive_student(self):
         """
         Logged in user without active student account
-        previously recieved a 500 error when fitering by status
+        previously received a 500 error when filtering by status
         """
         self.login(UserFactory.create())
         self.assertCatalogEmpty({"status": "unlocked"})

--- a/core/views.py
+++ b/core/views.py
@@ -25,7 +25,7 @@ from dashboard.models import PSet, UploadedFile
 from otisweb.utils import AuthHttpRequest
 from roster.models import Student
 
-from .forms import FilterForm
+from .forms import CatalogFilterForm
 from .models import Unit, UnitGroup
 from .utils import get_from_google_storage
 
@@ -91,18 +91,18 @@ class UnitGroupListView(ListView[Unit]):
         queryset = self.filter_queryset_form(queryset, form)
         return queryset
 
-    def get_form(self) -> FilterForm:
+    def get_form(self) -> CatalogFilterForm:
         if self.request.GET and any(
-            field in self.request.GET for field in FilterForm.base_fields.keys()
+            field in self.request.GET for field in CatalogFilterForm.base_fields.keys()
         ):
-            form = FilterForm(self.request.GET)
+            form = CatalogFilterForm(self.request.GET)
         else:
-            form = FilterForm()
+            form = CatalogFilterForm()
         self.form = form
         return form
 
     def filter_queryset_form(
-        self, queryset: QuerySet[Unit], form: FilterForm
+        self, queryset: QuerySet[Unit], form: CatalogFilterForm
     ) -> QuerySet[Unit]:
         if form.is_valid():
             # Filtering by difficulty

--- a/core/views.py
+++ b/core/views.py
@@ -2,7 +2,6 @@ from typing import Any, Optional
 
 from braces.views import LoginRequiredMixin, SuperuserRequiredMixin
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import PermissionDenied

--- a/core/views.py
+++ b/core/views.py
@@ -98,8 +98,7 @@ class UnitGroupListView(LoginRequiredMixin, ListView[Unit]):
 
     def get_form(self) -> CatalogFilterForm:
         if self.request.GET and any(
-            field in self.request.GET
-            for field in CatalogFilterForm.base_fields.keys()
+            field in self.request.GET for field in CatalogFilterForm.base_fields.keys()
         ):
             form = CatalogFilterForm(self.request.GET)
         else:

--- a/core/views.py
+++ b/core/views.py
@@ -2,6 +2,7 @@ from typing import Any, Optional
 
 from braces.views import LoginRequiredMixin, SuperuserRequiredMixin
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import PermissionDenied
@@ -40,7 +41,7 @@ class AdminUnitListView(SuperuserRequiredMixin, ListView[Unit]):
     context_object_name = "unit_list"
 
 
-class UnitGroupListView(ListView[Unit]):
+class UnitGroupListView(LoginRequiredMixin, ListView[Unit]):
     model = Unit
     context_object_name = "units"
     template_name = "core/unit_list.html"

--- a/core/views.py
+++ b/core/views.py
@@ -7,6 +7,7 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import PermissionDenied
 from django.db.models.aggregates import Count
 from django.db.models.base import Model
+from django.db.models.expressions import Value
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import Q
 from django.forms.models import BaseModelForm
@@ -86,6 +87,10 @@ class UnitGroupListView(ListView[Unit]):
                         filter=Q(student=student),
                     ),
                 )
+            else:
+                queryset = queryset.annotate(
+                    user_unlocked=Value(False), user_taking=Value(False)
+                )
 
         form = self.get_form()
         queryset = self.filter_queryset_form(queryset, form)
@@ -93,7 +98,8 @@ class UnitGroupListView(ListView[Unit]):
 
     def get_form(self) -> CatalogFilterForm:
         if self.request.GET and any(
-            field in self.request.GET for field in CatalogFilterForm.base_fields.keys()
+            field in self.request.GET
+            for field in CatalogFilterForm.base_fields.keys()
         ):
             form = CatalogFilterForm(self.request.GET)
         else:


### PR DESCRIPTION
Fix the 500 error when an inactive user tries to filter the catalog.

Additionally, require a login to access the (private) catalog.