### PR TITLE
edit: Added escape feature to ARCH

### DIFF
--- a/arch/templates/arch/hint_list.html
+++ b/arch/templates/arch/hint_list.html
@@ -5,7 +5,7 @@
 {% endblock title %}
 {% block layout-content %}
   <p>
-    <a href="{% url "arch-index" %}"><span class="emoji-text">⬅️</span> Back to ARCH index</a>
+    <a href="{% url "arch-index" %}" id="backToArch"><span class="emoji-text">⬅️</span> Back to ARCH index</a>
   </p>
   <hr />
   {% spaceless %}
@@ -75,3 +75,15 @@
     </a>
   </div>
 {% endblock layout-content %}
+{% block scripts %}
+<script defer>
+    document.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape') {
+            console.log('Escape pressed');
+            const link = document.getElementById('backToArch');
+            if (link) {
+                link.click();
+            }
+        }
+    });
+</script>

--- a/arch/templates/arch/hint_list.html
+++ b/arch/templates/arch/hint_list.html
@@ -75,7 +75,7 @@
     </a>
   </div>
 {% endblock layout-content %}
-{% block scripts %}
+
 <script defer>
     document.addEventListener('keydown', function (event) {
         if (event.key === 'Escape') {


### PR DESCRIPTION
When clicking escape from an ARCH hints page, it should lead back to the ARCH homepage.

This is intended to fix [Issue #332](https://github.com/vEnhance/otis-web/issues/332).

OTIS-WEB username: Kempu33334
ID number: 2312

If there is still a problem, please let me know.
