### PR TITLE
docs: update claude.md for Makefile and prek

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -8,6 +8,7 @@ Course management system for OTIS (Olympiad Training for Improving Scholars), a 
 - **Database:** MySQL
 - **Frontend:** Bootstrap 5, Django templates
 - **Package Management:** Poetry
+- **Code Quality:** prek (pre-commit hooks)
 - **Submodule:** `evans_django_tools` (shared utilities)
 
 ## Project Structure
@@ -34,41 +35,39 @@ fixtures/          # Test data (load with ./fixtures/load-all.sh)
 
 ## Development Commands
 
+All commands are available via Make:
+
 ```bash
+make help                   # Show all available commands
+
 # Setup
-poetry install                    # Install dependencies
-poetry shell                      # Activate virtual environment
-git submodule update --init       # Initialize evans_django_tools
+make install                # Install dependencies and prek hooks
+git submodule update --init # Initialize evans_django_tools
 
 # Database
-python manage.py migrate          # Apply migrations
-python manage.py makemigrations   # Create new migrations
-python manage.py createsuperuser  # Create admin user
-./fixtures/load-all.sh            # Load test data
+make migrate                # Apply migrations
+make makemigrations         # Create new migrations
+make createsuperuser        # Create admin user
+./fixtures/load-all.sh      # Load test data
 
 # Server
-python manage.py runserver        # Start development server
+make runserver              # Start development server (runserver_plus)
 
-# Testing
-python manage.py test             # Run all tests
-python manage.py test roster      # Test specific app
-coverage run manage.py test       # Run with coverage report
-
-# Code Quality (run all with ./lint.sh)
-ruff check --fix                  # Lint and auto-fix Python
-ruff format                       # Format Python code
-djlint --reformat .               # Format Django templates
-pyright                           # Type checking
-codespell                         # Spell checking
+# Testing & Code Quality
+make test                   # Run tests with coverage
+make check                  # Run Django checks and pyright type checking
+make fmt                    # Format all code (via prek)
+make prek                   # Run all prek hooks on all files
 ```
 
 ## Code Style
 
 - **Python:** Use type annotations (enforced by pyright), follow Google style guide
-- **Formatting:** `ruff format` for Python, `djlint` for templates
-- **Linting:** `ruff check` catches common issues
+- **Formatting:** `ruff format` for Python, `djlint` for templates, `prettier` for CSS/JS
+- **Linting:** `ruff check` catches common issues, `codespell` for spelling
 - **Templates:** 2-space indentation, Bootstrap 5 classes
-- Run `./lint.sh` before committing (or set up as pre-commit hook)
+- **Commits:** Conventional commits enforced (feat, fix, docs, etc.)
+- Run `make fmt` or `make prek` before committing (hooks auto-run on commit/push)
 
 ## Testing
 
@@ -77,14 +76,15 @@ codespell                         # Spell checking
 - Base class: `EvanTestCase` from `evans_django_tools.testsuite`
 - Common assertions: `assertGet20X()`, `assertGetDenied()`, `assertPost20X()`
 - All PRs must pass CI checks (GitHub Actions)
+- Pre-push hooks run `make check`, `make test`, and `make fmt`
 
 ## Key Files
 
 - `otisweb/settings.py` - Django configuration
 - `pyproject.toml` - Dependencies and tool configs
+- `Makefile` - Development commands
+- `.pre-commit-config.yaml` - prek/pre-commit hook configuration
 - `env` - Environment variable template (copy to `.env`)
-- `lint.sh` - Run all code quality checks
-- `autofix.sh` - Auto-format all code
 
 ## Environment Variables
 


### PR DESCRIPTION
Replace manual poetry/python commands with Makefile targets and
document prek hooks instead of the old lint.sh script.