### PR TITLE
tests: Fix unit test warnings and best practices

### DIFF
--- a/arch/factories.py
+++ b/arch/factories.py
@@ -18,6 +18,7 @@ from .models import Hint, Problem, Vote
 class ProblemFactory(DjangoModelFactory):
     class Meta:
         model = Problem
+        skip_postgeneration_save = True
 
     # TODO better way of all uppercase
     puid = Faker(

--- a/core/factories.py
+++ b/core/factories.py
@@ -27,6 +27,7 @@ class GroupFactory(DjangoModelFactory):
 class UserFactory(DjangoModelFactory):
     class Meta:
         model = User
+        skip_postgeneration_save = True
 
     first_name = Faker("first_name_female")
     last_name = Faker("last_name_female")
@@ -56,6 +57,7 @@ class UnitGroupFactory(DjangoModelFactory):
 class UnitFactory(DjangoModelFactory):
     class Meta:
         model = Unit
+        skip_postgeneration_save = True
 
     code = LazyAttribute(
         lambda o: random.choice("BDZ") + o.group.subject[0] + random.choice("WXY")

--- a/dashboard/tests.py
+++ b/dashboard/tests.py
@@ -23,7 +23,7 @@ from dashboard.factories import (
 )
 from dashboard.models import PSet, UploadedFile
 from dashboard.utils import get_news, get_units_to_submit, get_units_to_unlock
-from exams.factories import QuizFactory, TestFactory
+from exams.factories import PracticeExamFactory, QuizFactory
 from hanabi.factories import HanabiContestFactory
 from markets.factories import MarketFactory
 from opal.factories import OpalHuntFactory
@@ -79,7 +79,7 @@ def test_portal(otis):
     prevSemester = SemesterFactory.create(end_year=2020)
     StudentFactory.create(user=alice.user, semester=prevSemester)
 
-    test = TestFactory.create(
+    test = PracticeExamFactory.create(
         start_date=datetime.datetime(2021, 6, 1, tzinfo=UTC),
         due_date=datetime.datetime(2021, 7, 31, tzinfo=UTC),
         family="Waltz",

--- a/exams/factories.py
+++ b/exams/factories.py
@@ -13,9 +13,10 @@ from exams.models import ExamAttempt, PracticeExam
 from roster.factories import StudentFactory
 
 
-class TestFactory(DjangoModelFactory):
+class PracticeExamFactory(DjangoModelFactory):
     class Meta:
         model = PracticeExam
+        skip_postgeneration_save = True
 
     family = "Waltz"
     number = Sequence(lambda n: n + 1)
@@ -33,7 +34,7 @@ class TestFactory(DjangoModelFactory):
         )
 
 
-class QuizFactory(TestFactory):
+class QuizFactory(PracticeExamFactory):
     is_test = False
     answer1 = Faker("random_number", digits=3)
     answer2 = Faker("random_number", digits=3)

--- a/exams/tests.py
+++ b/exams/tests.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 
 from core.factories import SemesterFactory, UserFactory
 from exams.calculator import expr_compute
-from exams.factories import QuizFactory, TestFactory
+from exams.factories import PracticeExamFactory, QuizFactory
 from exams.models import ExamAttempt, PracticeExam
 from roster.factories import StudentFactory
 from roster.models import Student
@@ -57,7 +57,7 @@ def exam_setup():
     )
 
     with override_settings(TESTING_NEEDS_MOCK_MEDIA=True):
-        for factory in (TestFactory, QuizFactory):
+        for factory in (PracticeExamFactory, QuizFactory):
             for family in ("Waltz", "Foxtrot"):
                 factory.create(
                     start_date=datetime.datetime(2020, 1, 1, tzinfo=UTC),

--- a/fixtures/populate.py
+++ b/fixtures/populate.py
@@ -24,7 +24,7 @@ from core.factories import SemesterFactory, UserFactory, UserProfileFactory
 from core.models import Semester, Unit
 from dashboard.factories import PSetFactory, SemesterDownloadFileFactory
 from dashboard.models import PSet
-from exams.factories import ExamAttemptFactory, QuizFactory, TestFactory
+from exams.factories import ExamAttemptFactory, PracticeExamFactory, QuizFactory
 from exams.models import PracticeExam
 from hanabi.factories import HanabiContestFactory
 from markets.factories import GuessFactory, MarketFactory
@@ -156,7 +156,7 @@ def create_sem_independent(users: list[User]):
     # exams
     print(f"Creating {args.exam_num * 4} exam objects")
     fast_bulk_create(
-        TestFactory,
+        PracticeExamFactory,
         args.exam_num,
         family="Waltz",
         start_date=datetime.now(),
@@ -177,7 +177,7 @@ def create_sem_independent(users: list[User]):
     )
     last_year = datetime.now() + timedelta(days=-365)
     fast_bulk_create(
-        TestFactory,
+        PracticeExamFactory,
         args.exam_num,
         family="Foxtrot",
         start_date=last_year,

--- a/markets/factories.py
+++ b/markets/factories.py
@@ -27,6 +27,7 @@ class MarketFactory(DjangoModelFactory):
 class GuessFactory(DjangoModelFactory):
     class Meta:
         model = Guess
+        skip_postgeneration_save = True
 
     user = SubFactory(UserFactory)
     market = SubFactory(MarketFactory)

--- a/otisweb/settings.py
+++ b/otisweb/settings.py
@@ -47,6 +47,7 @@ else:
     ]
     SITE_URL = "http://127.0.0.1"
 SITE_ID = 1
+FORMS_URLFIELD_ASSUME_HTTPS = True
 TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
 if TESTING:
     assert DEBUG, "Don't run testing on production you big doofus"

--- a/rpg/tests.py
+++ b/rpg/tests.py
@@ -4,7 +4,7 @@ import pytest
 
 from core.factories import GroupFactory, UnitFactory, UserFactory
 from dashboard.factories import PSetFactory
-from exams.factories import ExamAttemptFactory, TestFactory
+from exams.factories import ExamAttemptFactory, PracticeExamFactory
 from payments.factories import JobFactory, WorkerFactory
 from roster.factories import StudentFactory
 from roster.models import Student
@@ -168,7 +168,7 @@ def test_multi_student_annotate(otis, alice_with_data):
     AchievementUnlockFactory.create(user=bob.user, achievement=a2)
 
     # spades
-    exam = TestFactory.create()
+    exam = PracticeExamFactory.create()
     ExamAttemptFactory.create(student=bob, score=3, quiz=exam)
     ExamAttemptFactory.create(student=carol, score=4, quiz=exam)
     ExamAttemptFactory.create(student=carol, score=2)

--- a/wikihaxx/factories.py
+++ b/wikihaxx/factories.py
@@ -20,6 +20,7 @@ class ArticleRevisionFactory(DjangoModelFactory):
 class ArticleFactory(DjangoModelFactory):
     class Meta:
         model = Article
+        skip_postgeneration_save = True
 
     @post_generation
     def set_current_revision(
@@ -27,6 +28,7 @@ class ArticleFactory(DjangoModelFactory):
     ):
         a: Article = self  # type: ignore
         a.current_revision = ArticleRevisionFactory(article=a)
+        a.save()
 
 
 class URLPathFactory(DjangoModelFactory):


### PR DESCRIPTION
- Rename TestFactory to PracticeExamFactory to avoid pytest collection warnings (pytest treats classes starting with "Test" as test classes)
- Add skip_postgeneration_save=True to factory Meta classes to follow factory_boy best practices and silence deprecation warnings
- Set FORMS_URLFIELD_ASSUME_HTTPS=True to opt into Django 6.0's HTTPS default for URL fields

Reduces test warnings from 1161 to 1 (the remaining warning is just Django noting the transitional setting will be removed in v6.0).

Describe what kind of changes you made here:
e.g. enhancement or feature update, bug fix, typos or copy edits, etc.

If you're an OTIS student, include your OTIS-WEB username or student ID number
(whichever you prefer) so I can grant you the spades bounty as well.
