### PR TITLE
fix: Fix flaky test_inquiry test in roster app

### DIFF
--- a/roster/tests.py
+++ b/roster/tests.py
@@ -434,7 +434,15 @@ def test_master_schedule(otis) -> None:
 def test_inquiry(otis) -> None:
     firefly: Assistant = AssistantFactory.create()
     alice: Student = StudentFactory.create(assistant=firefly)
-    units: list[Unit] = UnitFactory.create_batch(20)
+    # Create non-secret unit groups to avoid random subject="K" causing flaky tests
+    non_secret_groups = [
+        UnitGroupFactory.create(subject=subject)
+        for subject in ["A", "C", "G", "N", "F"]
+    ]
+    units: list[Unit] = [
+        UnitFactory.create(group=non_secret_groups[i % len(non_secret_groups)])
+        for i in range(20)
+    ]
     otis.login(alice)
 
     # Check that an invalid unit is not processed


### PR DESCRIPTION
The test_inquiry test was failing intermittently when run with pytest -n auto due to random subject assignment in UnitFactory. When units[19] (the 7th unit Alice tries to unlock) randomly got subject="K" (Secret), it would be auto- processed by the view logic at roster/views.py:351-352, even though the test expected it to NOT be auto-processed.

The view auto-processes secret units (subject "K") regardless of the student's unlock count, which caused the test assertion to fail approximately 12.5% of the time (1 in 8 possible subjects).

Fixed by explicitly creating units with non-secret subjects (A, C, G, N, F) instead of relying on random factory generation. The test later creates an explicit secret unit when testing that functionality.
