### PR TITLE
feat: show market start and end dates

### DIFF
--- a/markets/forms.py
+++ b/markets/forms.py
@@ -12,6 +12,8 @@ class MarketCreateForm(forms.ModelForm):
         fields = (
             "title",
             "slug",
+            "start_date",
+            "end_date",
             "answer",
             "show_answer",
             "int_guesses_only",


### PR DESCRIPTION
Previously, MarketCreateView automatically calculated start and end dates in form_valid() based on existing markets. Now these dates are shown as editable form fields with the calculated values as defaults.

Changes:
- Added start_date and end_date to MarketCreateForm fields
- Moved date calculation logic to get_initial() method in MarketCreateView
- Removed date-setting code from form_valid() since dates now come from form
- Updated test_create_market to explicitly provide dates in test data
- Added test_create_market_with_custom_dates to verify override capability

This allows admins to adjust market scheduling when needed while still providing sensible defaults based on the existing market schedule.