### PR TITLE
None option in catalog

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -166,6 +166,10 @@ class UnitGroupListView(LoginRequiredMixin, ListView[Unit]):
                         status_query |= Q(
                             user_taking=True, user_unlocked=False, has_pset=False
                         )
+                    if "none" in statuses:
+                        status_query |= Q(
+                            user_taking=False, user_unlocked=False, has_pset=False
+                        )
                     queryset = queryset.filter(status_query)
 
             sort_option = form.cleaned_data.get("sort")


### PR DESCRIPTION
I lowkey don't know if this works or not but I sure hope it does

It just adds a fourth "None" option to the catalog so you can see the units you don't have in your list, me personally I do this to see which B units I have left