### PR TITLE
feat: None option in catalog

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -21,6 +21,7 @@ class CatalogFilterForm(forms.Form):
             ("completed", "Done (✓)"),
             ("unlocked", "Unlocked (⏲)"),
             ("locked", "Locked (⧖)"),
+            ("none", "None"),
         ],
         widget=forms.CheckboxSelectMultiple(attrs={"class": "filter-form"}),
         required=False,


### PR DESCRIPTION
I lowkey don't know if this works or not but I sure hope it does

It just adds a fourth "None" option to the catalog so you can see the units you don't have in your list, me personally I do this to see which B units I have left