### PR TITLE
feat: show problem statement source on arch problem page

### DIFF
--- a/arch/templates/arch/hint_list.html
+++ b/arch/templates/arch/hint_list.html
@@ -15,15 +15,15 @@
   {% if statement %}
     <div class="alert-secondary alert">{{ statement|safe }}</div>
     <details class="mt-3 mb-4">
-      <summary><b>Show problem source</b></summary>
-      <pre style="
-        margin-top: 12px;
-        padding: 12px;
-        white-space: pre-wrap;
-        border: 1px solid #C4C8CB;
-        border-radius: 6px;
-        background: #E2E3E5;
-      ">{{ statement|escape }}</pre>
+      <summary>
+        <b>Show problem source</b>
+      </summary>
+      <pre style="margin-top: 12px;
+                  padding: 12px;
+                  white-space: pre-wrap;
+                  border: 1px solid #C4C8CB;
+                  border-radius: 6px;
+                  background: #E2E3E5;">{{ statement|escape }}</pre>
     </details>
   {% endif %}
   

--- a/arch/templates/arch/hint_list.html
+++ b/arch/templates/arch/hint_list.html
@@ -11,7 +11,6 @@
   {% spaceless %}
     <h1>{{ problem }}</h1>
   {% endspaceless %}
-
   {% if statement %}
     <div class="alert-secondary alert">{{ statement|safe }}</div>
     <details class="mt-3 mb-4">
@@ -23,10 +22,9 @@
                   white-space: pre-wrap;
                   border: 1px solid #C4C8CB;
                   border-radius: 6px;
-                  background: #E2E3E5;">{{ statement|escape }}</pre>
+                  background: #E2E3E5">{{ statement|escape }}</pre>
     </details>
   {% endif %}
-  
   {% if problem.hyperlink %}
     <p class="text-center">
       <a class="btn btn-secondary" href="{{ problem.hyperlink }}">

--- a/arch/templates/arch/hint_list.html
+++ b/arch/templates/arch/hint_list.html
@@ -11,7 +11,22 @@
   {% spaceless %}
     <h1>{{ problem }}</h1>
   {% endspaceless %}
-  {% if statement %}<div class="alert-secondary alert">{{ statement|safe }}</div>{% endif %}
+
+  {% if statement %}
+    <div class="alert-secondary alert">{{ statement|safe }}</div>
+    <details class="mt-3 mb-4">
+      <summary><b>Show problem source</b></summary>
+      <pre style="
+        margin-top: 12px;
+        padding: 12px;
+        white-space: pre-wrap;
+        border: 1px solid #C4C8CB;
+        border-radius: 6px;
+        background: #E2E3E5;
+      ">{{ statement|escape }}</pre>
+    </details>
+  {% endif %}
+  
   {% if problem.hyperlink %}
     <p class="text-center">
       <a class="btn btn-secondary" href="{{ problem.hyperlink }}">


### PR DESCRIPTION
Added "Show problem source" collapsible element below the problem statement to show the copyable source code of a problem in a box.