### PR TITLE
ci: is this my fault prly right

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 from django.test.utils import override_settings
+from django.utils.timezone import localtime
 
 from core.factories import (
     GroupFactory,
@@ -337,7 +338,7 @@ def test_userinfo_displays_info(otis):
     otis.assert_has(resp, "test@example.com")
     otis.assert_has(resp, "Test User")
     otis.assert_has(resp, "Testers")
-    otis.assert_has(resp, target_user.date_joined.strftime("%Y-%m-%d"))
+    otis.assert_has(resp, localtime(target_user.date_joined).strftime("%Y-%m-%d %H:%M"))
     assert target_user.last_login is None
     otis.assert_has(resp, "(never)")
 

--- a/prek.toml
+++ b/prek.toml
@@ -64,7 +64,7 @@ hooks = [{ id = "rumdl" }, { id = "rumdl-fmt" }]
 [[repos]]
 repo = "https://github.com/zizmorcore/zizmor-pre-commit"
 rev = "v1.28.0"
-hooks = [{ id = "zizmor" }]
+hooks = [{ id = "zizmor", args = ["--offline"] }]
 
 [[repos]]
 repo = "https://github.com/shellcheck-py/shellcheck-py"


### PR DESCRIPTION
`test_userinfo_displays_info` formatted `date_joined` in UTC while the template renders it through the `date` filter, which converts to settings.TIME_ZONE (America/New_York). The two disagree about the calendar date for the first 4-5 hours of every UTC day, so the test fails on any UTC-clocked machine -- including GitHub Actions -- when it happens to run in that window.

Format via `localtime()` and assert the full rendered timestamp.

Also pass `--offline` to the zizmor hook. Its online audits reach the GitHub API and are already skipped in CI (the job exports no token), so pinning the flag makes local runs match CI instead of failing on whatever token happens to be in the environment.
