### PR TITLE
fix(arch): implement #495 correctly

### DIFF
--- a/arch/models.py
+++ b/arch/models.py
@@ -1,40 +1,16 @@
-import string
-from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import reversion
-from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import SuspiciousOperation
 from django.core.validators import MaxValueValidator, RegexValidator
 from django.db import models
 from django.db.models.manager import Manager
-from django.http import Http404
 from django.urls import reverse
+
+from arch.utils import get_disk_statement_from_puid
 
 if TYPE_CHECKING:
     assert hasattr(reversion, "register")
-
-
-def validate_puid(puid: str) -> None:
-    if not all(_ in string.ascii_letters + string.digits for _ in puid):
-        raise Http404(f"The PUID {puid} contains illegal characters.")
-    elif len(puid) > 32:
-        raise Http404(f"The PUID {puid} is too long to be possible.")
-
-
-def get_disk_statement_from_puid(puid: str) -> Optional[str]:
-    validate_puid(puid)
-    if settings.PATH_STATEMENT_ON_DISK is None:
-        return None
-    base_path = Path(settings.PATH_STATEMENT_ON_DISK).resolve()
-    statement_path = (base_path / f"{puid}.html").resolve()
-    if statement_path.parent != base_path:
-        raise SuspiciousOperation(f"oh this is really bad ur so screwed ({puid})")
-    elif statement_path.exists() and statement_path.is_file():
-        return statement_path.read_text()
-    else:
-        return None
 
 
 # Create your models here.
@@ -64,8 +40,11 @@ class Problem(models.Model):
     def get_absolute_url(self):
         return reverse("hint-list", args=(self.puid,))
 
-    def get_statement(self) -> Optional[str]:
-        return get_disk_statement_from_puid(self.puid)
+    def get_html_statement(self) -> Optional[str]:
+        return get_disk_statement_from_puid(self.puid, "html")
+
+    def get_tex_statement(self) -> Optional[str]:
+        return get_disk_statement_from_puid(self.puid, "tex")
 
     @property
     def niceness(self) -> Optional[float]:

--- a/arch/templates/arch/hint_list.html
+++ b/arch/templates/arch/hint_list.html
@@ -11,8 +11,10 @@
   {% spaceless %}
     <h1>{{ problem }}</h1>
   {% endspaceless %}
-  {% if statement %}
-    <div class="alert-secondary alert">{{ statement|safe }}</div>
+  {% if html_statement %}
+    <div class="alert-secondary alert">{{ html_statement|safe }}</div>
+  {% endif %}
+  {% if tex_statement %}
     <details class="mt-3 mb-4">
       <summary>
         <b>Show problem source</b>
@@ -22,7 +24,7 @@
                   white-space: pre-wrap;
                   border: 1px solid #C4C8CB;
                   border-radius: 6px;
-                  background: #E2E3E5">{{ statement|escape }}</pre>
+                  background: #E2E3E5">{{ tex_statement|escape }}</pre>
     </details>
   {% endif %}
   {% if problem.hyperlink %}
@@ -82,7 +84,7 @@
   </div>
   <hr />
   <div class="text-center">
-    {% if statement %}
+    {% if html_statement %}
       <a href="{% url "view-solution" problem.puid %}" class="btn btn-info">
         <span class="emoji-text">📜</span> Solution (TeX)
       </a>

--- a/arch/tests.py
+++ b/arch/tests.py
@@ -45,6 +45,16 @@ def test_disk_problem(otis):
     otis.assert_has(resp, "<p>rock and roll</p>")
     otis.assert_has(resp, r"Show that $x &lt; y$ \emph{rocks and rolls}.")
 
+    # the PUID is used verbatim: uppercasing inside the lookup would let
+    # view_solution pass this check and then 500 on the lowercase solution.
+    # (skipped when the filesystem itself is case-insensitive)
+    lower_path = os.path.join(
+        settings.PATH_STATEMENT_ON_DISK, f"{disk_puid.lower()}.html"
+    )
+    if not os.path.exists(lower_path):
+        assert get_disk_statement_from_puid(disk_puid.lower()) is None
+        otis.get_40x("view-solution", disk_puid.lower())
+
     os.remove(html_path)
     os.remove(tex_path)
     if not os.listdir(settings.PATH_STATEMENT_ON_DISK):

--- a/arch/tests.py
+++ b/arch/tests.py
@@ -7,7 +7,8 @@ from django.test import override_settings
 from django.urls import reverse
 
 from arch.factories import HintFactory, ProblemFactory
-from arch.models import Hint, Problem, Vote, validate_puid
+from arch.models import Hint, Problem, Vote
+from arch.utils import get_disk_statement_from_puid, validate_puid
 from core.factories import GroupFactory, UserFactory
 from core.models import UserProfile
 
@@ -26,10 +27,13 @@ def test_disk_problem(otis):
     if not os.path.exists(settings.PATH_STATEMENT_ON_DISK):
         os.makedirs(settings.PATH_STATEMENT_ON_DISK)
 
-    problem_path = os.path.join(settings.PATH_STATEMENT_ON_DISK, f"{disk_puid}.html")
+    html_path = os.path.join(settings.PATH_STATEMENT_ON_DISK, f"{disk_puid}.html")
+    tex_path = os.path.join(settings.PATH_STATEMENT_ON_DISK, f"{disk_puid}.tex")
 
-    with open(problem_path, "w", encoding="utf_8") as f:
-        f.write("rock and roll")
+    with open(html_path, "w", encoding="utf_8") as f:
+        f.write("<p>rock and roll</p>")
+    with open(tex_path, "w", encoding="utf_8") as f:
+        f.write(r"Show that $x < y$ \emph{rocks and rolls}.")
 
     otis.get_40x("hint-list", "NONEXISTENT")
     resp = otis.get_20x("hint-list", disk_puid)
@@ -37,9 +41,42 @@ def test_disk_problem(otis):
     messages = [m.message for m in resp.context["messages"]]
     assert f"Created previously nonexistent problem {disk_puid}" in messages
 
-    otis.assert_has(resp, "rock and roll")
+    # the HTML statement is rendered as-is, the TeX source is shown escaped
+    otis.assert_has(resp, "<p>rock and roll</p>")
+    otis.assert_has(resp, r"Show that $x &lt; y$ \emph{rocks and rolls}.")
 
-    os.remove(problem_path)
+    os.remove(html_path)
+    os.remove(tex_path)
+    if not os.listdir(settings.PATH_STATEMENT_ON_DISK):
+        os.rmdir(settings.PATH_STATEMENT_ON_DISK)
+
+
+@pytest.mark.django_db
+@override_settings(
+    PATH_STATEMENT_ON_DISK=os.path.join(settings.BASE_DIR, "test_static/")
+)
+def test_disk_statement_missing_tex(otis):
+    """An HTML statement with no TeX source next to it should still render."""
+    verified_group = GroupFactory(name="Verified")
+    alice = UserFactory.create(groups=(verified_group,))
+    otis.login(alice)
+
+    disk_puid = "LONELY"
+
+    if not os.path.exists(settings.PATH_STATEMENT_ON_DISK):
+        os.makedirs(settings.PATH_STATEMENT_ON_DISK)
+
+    html_path = os.path.join(settings.PATH_STATEMENT_ON_DISK, f"{disk_puid}.html")
+    with open(html_path, "w", encoding="utf_8") as f:
+        f.write("<p>no source here</p>")
+
+    assert get_disk_statement_from_puid(disk_puid, "tex") is None
+
+    resp = otis.get_20x("hint-list", disk_puid)
+    otis.assert_has(resp, "<p>no source here</p>")
+    assert "Show problem source" not in resp.content.decode()
+
+    os.remove(html_path)
     if not os.listdir(settings.PATH_STATEMENT_ON_DISK):
         os.rmdir(settings.PATH_STATEMENT_ON_DISK)
 

--- a/arch/utils.py
+++ b/arch/utils.py
@@ -27,24 +27,20 @@ def get_disk_statement_from_puid(
     ``{puid}.html`` (the rendered statement, meant to be displayed as HTML)
     and ``{puid}.tex`` (the raw TeX source of the same statement).
     Returns ``None`` if no such file is available.
+
+    The PUID is used verbatim, so callers are responsible for normalizing
+    its case; the files on disk are named after uppercase PUIDs.
     """
-    puid = puid.upper()
     validate_puid(puid)
-    if fmt not in ("html", "tex"):
-        raise SuspiciousOperation(f"Illegal statement format requested: {fmt}")
     if settings.PATH_STATEMENT_ON_DISK is None:
         return None
     base_path = Path(settings.PATH_STATEMENT_ON_DISK).resolve()
-    if not base_path.exists() or not base_path.is_dir():
-        return None
-
-    statement_name = f"{puid}.{fmt}"
-    statement_path = base_path.joinpath(statement_name).resolve()
-    try:
-        statement_path.relative_to(base_path)
-    except ValueError:
+    statement_path = (base_path / f"{puid}.{fmt}").resolve()
+    # validate_puid already rules out separators and dots, but insist that
+    # the statement be a direct child of the statement directory anyway
+    if statement_path.parent != base_path:
         raise SuspiciousOperation(f"oh this is really bad ur so screwed ({puid})")
-    if statement_path.exists() and statement_path.is_file():
+    elif statement_path.exists() and statement_path.is_file():
         return statement_path.read_text()
     else:
         return None

--- a/arch/utils.py
+++ b/arch/utils.py
@@ -27,13 +27,18 @@ def get_disk_statement_from_puid(
     Returns ``None`` if no such file is available.
     """
     validate_puid(puid)
+    if fmt not in ("html", "tex"):
+        raise SuspiciousOperation(f"Illegal statement format requested: {fmt}")
     if settings.PATH_STATEMENT_ON_DISK is None:
         return None
     base_path = Path(settings.PATH_STATEMENT_ON_DISK).resolve()
-    statement_path = (base_path / f"{puid}.{fmt}").resolve()
-    if statement_path.parent != base_path:
+    statement_name = f"{puid}.{fmt}"
+    statement_path = (base_path / statement_name).resolve()
+    try:
+        statement_path.relative_to(base_path)
+    except ValueError:
         raise SuspiciousOperation(f"oh this is really bad ur so screwed ({puid})")
-    elif statement_path.exists() and statement_path.is_file():
+    if statement_path.exists() and statement_path.is_file():
         return statement_path.read_text()
     else:
         return None

--- a/arch/utils.py
+++ b/arch/utils.py
@@ -10,6 +10,8 @@ StatementFormat = Literal["html", "tex"]
 
 
 def validate_puid(puid: str) -> None:
+    if not puid:
+        raise Http404("The PUID cannot be empty.")
     if not all(_ in string.ascii_letters + string.digits for _ in puid):
         raise Http404(f"The PUID {puid} contains illegal characters.")
     elif len(puid) > 32:
@@ -26,14 +28,18 @@ def get_disk_statement_from_puid(
     and ``{puid}.tex`` (the raw TeX source of the same statement).
     Returns ``None`` if no such file is available.
     """
+    puid = puid.upper()
     validate_puid(puid)
     if fmt not in ("html", "tex"):
         raise SuspiciousOperation(f"Illegal statement format requested: {fmt}")
     if settings.PATH_STATEMENT_ON_DISK is None:
         return None
     base_path = Path(settings.PATH_STATEMENT_ON_DISK).resolve()
+    if not base_path.exists() or not base_path.is_dir():
+        return None
+
     statement_name = f"{puid}.{fmt}"
-    statement_path = (base_path / statement_name).resolve()
+    statement_path = base_path.joinpath(statement_name).resolve()
     try:
         statement_path.relative_to(base_path)
     except ValueError:

--- a/arch/utils.py
+++ b/arch/utils.py
@@ -1,0 +1,39 @@
+import string
+from pathlib import Path
+from typing import Literal, Optional
+
+from django.conf import settings
+from django.core.exceptions import SuspiciousOperation
+from django.http import Http404
+
+StatementFormat = Literal["html", "tex"]
+
+
+def validate_puid(puid: str) -> None:
+    if not all(_ in string.ascii_letters + string.digits for _ in puid):
+        raise Http404(f"The PUID {puid} contains illegal characters.")
+    elif len(puid) > 32:
+        raise Http404(f"The PUID {puid} is too long to be possible.")
+
+
+def get_disk_statement_from_puid(
+    puid: str, fmt: StatementFormat = "html"
+) -> Optional[str]:
+    """Reads a problem statement for the given PUID off disk.
+
+    The statements live in ``settings.PATH_STATEMENT_ON_DISK`` as
+    ``{puid}.html`` (the rendered statement, meant to be displayed as HTML)
+    and ``{puid}.tex`` (the raw TeX source of the same statement).
+    Returns ``None`` if no such file is available.
+    """
+    validate_puid(puid)
+    if settings.PATH_STATEMENT_ON_DISK is None:
+        return None
+    base_path = Path(settings.PATH_STATEMENT_ON_DISK).resolve()
+    statement_path = (base_path / f"{puid}.{fmt}").resolve()
+    if statement_path.parent != base_path:
+        raise SuspiciousOperation(f"oh this is really bad ur so screwed ({puid})")
+    elif statement_path.exists() and statement_path.is_file():
+        return statement_path.read_text()
+    else:
+        return None

--- a/arch/views.py
+++ b/arch/views.py
@@ -16,7 +16,7 @@ from django_discordo import ACTION_LOG_LEVEL
 from reversion.views import RevisionMixin
 
 from arch.forms import ProblemSelectForm
-from arch.utils import get_disk_statement_from_puid
+from arch.utils import get_disk_statement_from_puid, validate_puid
 from core.models import UserProfile
 from core.utils import get_protected_file
 from otisweb.decorators import verified_required
@@ -66,7 +66,9 @@ class HintList(VerifiedRequiredMixin, ListView[Hint]):
     def get_context_data(self, **kwargs: Any):
         context = super().get_context_data(**kwargs)
 
-        puid = self.kwargs["puid"].upper()
+        raw_puid = self.kwargs["puid"]
+        validate_puid(raw_puid)
+        puid = raw_puid.upper()
         try:
             self.problem = Problem.objects.get(puid=puid)
         except Problem.DoesNotExist:
@@ -267,6 +269,7 @@ def lookup(request: HttpRequest):
 @login_required
 @verified_required
 def view_solution(request: HttpRequest, puid: str) -> HttpResponse:
+    validate_puid(puid)
     if get_disk_statement_from_puid(puid) is None:
         raise Http404(
             f"The problem {puid} is not in the OTIS database, "

--- a/arch/views.py
+++ b/arch/views.py
@@ -16,7 +16,7 @@ from django_discordo import ACTION_LOG_LEVEL
 from reversion.views import RevisionMixin
 
 from arch.forms import ProblemSelectForm
-from arch.models import get_disk_statement_from_puid
+from arch.utils import get_disk_statement_from_puid
 from core.models import UserProfile
 from core.utils import get_protected_file
 from otisweb.decorators import verified_required
@@ -81,7 +81,8 @@ class HintList(VerifiedRequiredMixin, ListView[Hint]):
                 raise Http404(f"Couldn't find {puid} in database or disk")
 
         context["problem"] = self.problem
-        context["statement"] = self.problem.get_statement()
+        context["html_statement"] = self.problem.get_html_statement()
+        context["tex_statement"] = self.problem.get_tex_statement()
         context["hints_disabled"] = UserProfile.objects.filter(
             user=self.request.user, disable_hints=True
         ).exists()


### PR DESCRIPTION
The "Show problem source" block added in #495 reused the rendered {puid}.html file, so it displayed escaped HTML rather than the TeX source of the statement. Read {puid}.tex from the same directory instead.

get_disk_statement_from_puid now takes a format argument ("html" or "tex") and lives in the new arch/utils.py alongside validate_puid, which is a better home for it than arch/models.py. Problem exposes it as get_html_statement()/get_tex_statement(), and hint_list.html renders html_statement with |safe and tex_statement with |escape.
