### PR TITLE
feat: strip django log file from response logging

### DIFF
--- a/otisweb/settings.py
+++ b/otisweb/settings.py
@@ -2,10 +2,12 @@
 Django settings for otisweb project.
 """
 
+import inspect
 import logging
 import os
+import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import django_discordo
 import django_stubs_ext
@@ -310,6 +312,33 @@ def add_username(record: logging.LogRecord):
     return True
 
 
+# Return location of the view that handled a request.
+def _view_location(request: Any) -> Optional[tuple[str, str, int]]:
+    match = getattr(request, "resolver_match", None)
+    if match is None:
+        return None
+    # for a class-based view, func is the closure that as_view() returned
+    target = getattr(match.func, "view_class", None) or inspect.unwrap(match.func)
+    code = getattr(target, "__code__", None)
+    if code is not None:
+        return match._func_path, code.co_filename, code.co_firstlineno
+    module = sys.modules.get(getattr(target, "__module__", ""))
+    path = getattr(module, "__file__", None)
+    if path is None:
+        return None
+    return match._func_path, path, getattr(target, "__firstlineno__", 0)
+
+
+def fix_response_location(record: logging.LogRecord) -> bool:
+    if not record.pathname.endswith(os.path.join("django", "utils", "log.py")):
+        return True
+    location = _view_location(getattr(record, "request", None))
+    if location is not None:
+        record.module, record.pathname, record.lineno = location
+        record.filename = os.path.basename(record.pathname)
+    return True
+
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -334,18 +363,31 @@ LOGGING = {
             "()": "django.utils.log.CallbackFilter",
             "callback": add_username,
         },
+        "fix_response_location": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": fix_response_location,
+        },
     },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
             "level": "VERBOSE",
             "formatter": "stream_format",
-            "filters": ["filter_oserror_write", "add_username"],
+            "filters": [
+                "filter_oserror_write",
+                "add_username",
+                "fix_response_location",
+            ],
         },
         "discord": {
             "class": "django_discordo.DiscordWebhookHandler",
             "level": "VERBOSE",
-            "filters": ["require_debug_false", "filter_oserror_write", "add_username"],
+            "filters": [
+                "require_debug_false",
+                "filter_oserror_write",
+                "add_username",
+                "fix_response_location",
+            ],
         },
     },
     "root": {

--- a/otisweb/tests.py
+++ b/otisweb/tests.py
@@ -1,7 +1,14 @@
+import logging
+import os
+
 import pytest
-from django.test import Client
+from django.http import HttpResponse
+from django.test import Client, RequestFactory
+from django.urls import Resolver404, resolve
+from django.utils.log import log_response
 
 from core.factories import UserFactory
+from otisweb.settings import fix_response_location
 
 
 @pytest.mark.django_db
@@ -53,3 +60,60 @@ def test_wiki_redirects_to_catalog(client: Client, path: str):
 @pytest.mark.parametrize("path", ("/wikipedia/", "/wikis/"))
 def test_wiki_redirect_does_not_overreach(client: Client, path: str):
     assert client.get(path).status_code == 404
+
+
+class _Capture(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+        self.addFilter(fix_response_location)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _log_server_error(rf: RequestFactory, path: str) -> logging.LogRecord:
+    request = rf.get(path)
+    try:
+        request.resolver_match = resolve(path)
+    except Resolver404:
+        pass
+    logger = logging.getLogger("otisweb.tests.response_location")
+    logger.propagate = False
+    handler = _Capture()
+    logger.addHandler(handler)
+    try:
+        log_response(
+            "Internal Server Error: %s",
+            path,
+            response=HttpResponse(status=500),
+            request=request,
+            logger=logger,
+        )
+    finally:
+        logger.removeHandler(handler)
+    (record,) = handler.records
+    return record
+
+
+def test_response_location_unfiltered(rf: RequestFactory):
+    record = _log_server_error(rf, "/nonexistent/")
+    assert record.module == "log"
+    assert record.pathname.endswith(os.path.join("django", "utils", "log.py"))
+
+
+@pytest.mark.parametrize(
+    "path,expected_module",
+    (
+        ("/arch/", "arch.views.ProblemCreate"),
+        ("/dash/portal/1/", "dashboard.views.portal"),
+    ),
+)
+def test_response_location_view(rf: RequestFactory, path: str, expected_module: str):
+    record = _log_server_error(rf, path)
+    assert record.module == expected_module
+    assert record.filename == "views.py"
+    assert record.pathname.endswith(
+        os.path.join(expected_module.split(".")[0], "views.py")
+    )
+    assert record.lineno > 0


### PR DESCRIPTION
errors always log with scope `django.request` and filename 249:`log.py`. you can't really strip one level of the stacktrace, but you can get a better location by getting the view

this is independent from https://github.com/vEnhance/django-discordo/pull/3 , and can be merged before/after that