### PR TITLE
feat(arch): 404 if solution not found

### DIFF
--- a/arch/tests.py
+++ b/arch/tests.py
@@ -241,6 +241,31 @@ def test_view_solution(otis):
     assert resp.status_code == 404
 
 
+@pytest.mark.django_db
+@override_settings(
+    PATH_STATEMENT_ON_DISK=os.path.join(settings.BASE_DIR, "test_static/")
+)
+def test_view_solution_without_solution_on_bucket(otis):
+    verified_group = GroupFactory(name="Verified")
+    alice = UserFactory.create(groups=(verified_group,))
+    otis.login(alice)
+
+    disk_puid = "SOLLESS"
+
+    if not os.path.exists(settings.PATH_STATEMENT_ON_DISK):
+        os.makedirs(settings.PATH_STATEMENT_ON_DISK)
+    html_path = os.path.join(settings.PATH_STATEMENT_ON_DISK, f"{disk_puid}.html")
+    with open(html_path, "w", encoding="utf_8") as f:
+        f.write("<p>statement without solution</p>")
+
+    assert get_disk_statement_from_puid(disk_puid) is not None
+    otis.get_not_found("view-solution", disk_puid)
+
+    os.remove(html_path)
+    if not os.listdir(settings.PATH_STATEMENT_ON_DISK):
+        os.rmdir(settings.PATH_STATEMENT_ON_DISK)
+
+
 def test_validate_puid():
     with pytest.raises(Http404):
         validate_puid("✈✈✈")

--- a/arch/views.py
+++ b/arch/views.py
@@ -275,7 +275,8 @@ def view_solution(request: HttpRequest, puid: str) -> HttpResponse:
             f"The problem {puid} is not in the OTIS database, "
             "therefore no solution file could be retrieved."
         )
-    return get_protected_file("arch-sol", f"{puid}.tex", request)
+    # statement is on disk and solution is in bucket, which can drift...
+    return get_protected_file("arch-sol", f"{puid}.tex", request, missing_is_404=True)
 
 
 class VoteCreate(

--- a/core/utils.py
+++ b/core/utils.py
@@ -3,7 +3,7 @@ import logging
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.core.files.storage import storages
-from django.http import HttpRequest
+from django.http import Http404, HttpRequest
 from django.http.response import (
     HttpResponse,
     HttpResponseBadRequest,
@@ -16,7 +16,9 @@ from core.watermark import watermark_pdf
 logger = logging.getLogger(__name__)
 
 
-def get_protected_file(folder: str, filename: str, request: HttpRequest):
+def get_protected_file(
+    folder: str, filename: str, request: HttpRequest, missing_is_404: bool = False
+):
     if not isinstance(request.user, User):
         raise PermissionDenied("Only logged in users may query core storage.")
     profile, _ = UserProfile.objects.get_or_create(user=request.user)
@@ -31,6 +33,8 @@ def get_protected_file(folder: str, filename: str, request: HttpRequest):
     try:
         file = storage.open(path)
     except FileNotFoundError:
+        if missing_is_404:
+            raise Http404(f"No file named {filename} is available.")
         errmsg = f"Unable to find {filename} at {path}."
         logger.critical(errmsg)
         return HttpResponseServerError("File not found")


### PR DESCRIPTION
Somewhat RFC. Right now we 500 if arch finds the statement but not the solution; this changes it to a 404.

Semantically these _should_ be 404s. In the arch-sol case it's expected that we can't find things in the bucket sometimes, so a 500 is inappropriate. Also, they fire both a critical _and_ an error log, and my SRE brain believes that the steady state of prod should have no 5xy errors.