### PR TITLE
feat(tubes): casual-mode page listing full statements by subject

### DIFF
--- a/tubes/templates/tubes/casual_browse.html
+++ b/tubes/templates/tubes/casual_browse.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% load django_bootstrap5 %}
 {% block title %}
   Casual {{ subject_name }} Problems
 {% endblock title %}
@@ -9,27 +10,47 @@
     {% include "tubes/components/casual_subject_nav.html" %}
   </div>
   <p class="text-muted">
-    Every {{ subject_name }} problem you haven't opened yet, statement and all.
+    Every {{ subject_name }} problem, statement and all, newest first.
     Scroll until you find one you'd like to try;
     nothing here is timed or recorded.
-    Answers and solutions stay hidden until you open a problem and reveal them.
+    Problems you've already seen are greyed out,
+    and answers and solutions stay hidden
+    until you open a problem and reveal them.
   </p>
-  {% for proposal in proposals %}
-    <div class="card mb-4">
+  {% for proposal in page_obj %}
+    <div class="card mb-4 {% if proposal.spoiled %}border-secondary{% else %}border-primary{% endif %}">
       <div class="card-header d-flex justify-content-between align-items-start gap-2">
         <span class="fw-bold">
           <a href="{{ proposal.get_absolute_url }}">{{ proposal.label }}</a>: {{ proposal.title }}
+          {% if proposal.browse_status == "author" %}
+            <span class="badge bg-secondary">Yours</span>
+          {% elif proposal.browse_status == "solved" %}
+            <span class="badge bg-secondary">Solved</span>
+          {% elif proposal.browse_status == "attempted" %}
+            <span class="badge bg-secondary">Attempted</span>
+          {% elif proposal.browse_status == "revealed" %}
+            <span class="badge bg-secondary">Spoiled</span>
+          {% else %}
+            <span class="badge bg-primary">New</span>
+          {% endif %}
         </span>
         <span class="text-nowrap">🩷 × {{ proposal.upvote_count }} · {{ proposal.difficulty_display }}</span>
       </div>
       <div class="card-body">
-        <div class="math-content">{{ proposal.statement }}</div>
+        <div class="math-content {% if proposal.spoiled %}text-muted{% endif %}">{{ proposal.statement }}</div>
       </div>
       <div class="card-footer">
-        <a href="{{ proposal.get_absolute_url }}">Open {{ proposal.label }} to check your answer →</a>
+        {% if proposal.spoiled %}
+          <a href="{{ proposal.get_absolute_url }}">Open {{ proposal.label }} →</a>
+        {% else %}
+          <a href="{{ proposal.get_absolute_url }}">Open {{ proposal.label }} to check your answer →</a>
+        {% endif %}
       </div>
     </div>
   {% empty %}
-    <div class="alert alert-warning">There are no {{ subject_name }} problems left that you haven't already seen.</div>
+    <div class="alert alert-warning">There are no {{ subject_name }} problems yet.</div>
   {% endfor %}
+  {% if page_obj.has_other_pages %}
+    {% bootstrap_pagination page_obj justify_content="center" %}
+  {% endif %}
 {% endblock layout-content %}

--- a/tubes/templates/tubes/casual_browse.html
+++ b/tubes/templates/tubes/casual_browse.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% load django_bootstrap5 %}
 {% block title %}
-  Casual {{ subject_name }} Problems
+  {{ subject_name }} Problems (Casual)
 {% endblock title %}
 {% block layout-content %}
   <div class="mb-3">
@@ -9,46 +9,34 @@
        class="btn btn-outline-secondary btn-sm">← All problems</a>
     {% include "tubes/components/casual_subject_nav.html" %}
   </div>
-  <p class="text-muted">
-    Every {{ subject_name }} problem, statement and all, newest first.
-    Scroll until you find one you'd like to try;
-    nothing here is timed or recorded.
-    Problems you've already seen are greyed out,
-    and answers and solutions stay hidden
-    until you open a problem and reveal them.
-  </p>
+  <p>Showing all {{ subject_name }} problems in casual mode.</p>
   {% for proposal in page_obj %}
     <div class="card mb-4 {% if proposal.spoiled %}border-secondary{% else %}border-primary{% endif %}">
       <div class="card-header d-flex justify-content-between align-items-start gap-2">
         <span class="fw-bold">
-          <a href="{{ proposal.get_absolute_url }}">{{ proposal.label }}</a>: {{ proposal.title }}
-          {% if proposal.browse_status == "author" %}
-            <span class="badge bg-secondary">Yours</span>
-          {% elif proposal.browse_status == "solved" %}
-            <span class="badge bg-secondary">Solved</span>
-          {% elif proposal.browse_status == "attempted" %}
-            <span class="badge bg-secondary">Attempted</span>
-          {% elif proposal.browse_status == "revealed" %}
-            <span class="badge bg-secondary">Spoiled</span>
-          {% else %}
-            <span class="badge bg-primary">New</span>
-          {% endif %}
+          <a href="{{ proposal.get_absolute_url }}">{{ proposal.label }}: {{ proposal.title }}</a>
         </span>
         <span class="text-nowrap">🩷 × {{ proposal.upvote_count }} · {{ proposal.difficulty_display }}</span>
       </div>
       <div class="card-body">
         <div class="math-content {% if proposal.spoiled %}text-muted{% endif %}">{{ proposal.statement }}</div>
       </div>
-      <div class="card-footer">
-        {% if proposal.spoiled %}
-          <a href="{{ proposal.get_absolute_url }}">Open {{ proposal.label }} →</a>
+      <div class="card-footer text-muted fst-italic">
+        {% if proposal.browse_status == "author" %}
+          You are the author of this problem!
+        {% elif proposal.browse_status == "solved" %}
+          You solved this problem under ranked mode. Nice!
+        {% elif proposal.browse_status == "attempted" %}
+          You previously attempted this problem under ranked mode.
+        {% elif proposal.browse_status == "revealed" %}
+          You are spoiled on this problem.
         {% else %}
-          <a href="{{ proposal.get_absolute_url }}">Open {{ proposal.label }} to check your answer →</a>
+          You haven't read the solution to this problem yet.
         {% endif %}
       </div>
     </div>
   {% empty %}
-    <div class="alert alert-warning">There are no {{ subject_name }} problems yet.</div>
+    <p class="fw-bold">There are no {{ subject_name }} problems yet.</p>
   {% endfor %}
   {% if page_obj.has_other_pages %}
     {% bootstrap_pagination page_obj justify_content="center" %}

--- a/tubes/templates/tubes/casual_browse.html
+++ b/tubes/templates/tubes/casual_browse.html
@@ -1,0 +1,35 @@
+{% extends "layout.html" %}
+{% block title %}
+  Casual {{ subject_name }} Problems
+{% endblock title %}
+{% block layout-content %}
+  <div class="mb-3">
+    <a href="{% url "oime-proposal-list" %}"
+       class="btn btn-outline-secondary btn-sm">← All problems</a>
+    {% include "tubes/components/casual_subject_nav.html" %}
+  </div>
+  <p class="text-muted">
+    Every {{ subject_name }} problem you haven't opened yet, statement and all.
+    Scroll until you find one you'd like to try;
+    nothing here is timed or recorded.
+    Answers and solutions stay hidden until you open a problem and reveal them.
+  </p>
+  {% for proposal in proposals %}
+    <div class="card mb-4">
+      <div class="card-header d-flex justify-content-between align-items-start gap-2">
+        <span class="fw-bold">
+          <a href="{{ proposal.get_absolute_url }}">{{ proposal.label }}</a>: {{ proposal.title }}
+        </span>
+        <span class="text-nowrap">🩷 × {{ proposal.upvote_count }} · {{ proposal.difficulty_display }}</span>
+      </div>
+      <div class="card-body">
+        <div class="math-content">{{ proposal.statement }}</div>
+      </div>
+      <div class="card-footer">
+        <a href="{{ proposal.get_absolute_url }}">Open {{ proposal.label }} to check your answer →</a>
+      </div>
+    </div>
+  {% empty %}
+    <div class="alert alert-warning">There are no {{ subject_name }} problems left that you haven't already seen.</div>
+  {% endfor %}
+{% endblock layout-content %}

--- a/tubes/templates/tubes/components/casual_subject_nav.html
+++ b/tubes/templates/tubes/components/casual_subject_nav.html
@@ -5,5 +5,5 @@ page currently being viewed, if any).
 {% endcomment %}
 {% for code, name in subject_choices %}
   <a href="{% url "oime-casual-browse" code %}"
-     class="btn btn-sm {% if code == subject %}btn-primary{% else %}btn-outline-primary{% endif %}">{{ name }}</a>
+     class="btn btn-sm {% if code == subject %}btn-primary{% else %}btn-outline-primary{% endif %}">{{ code }}</a>
 {% endfor %}

--- a/tubes/templates/tubes/components/casual_subject_nav.html
+++ b/tubes/templates/tubes/components/casual_subject_nav.html
@@ -1,0 +1,9 @@
+{% comment %}
+Links into the casual full-statement browser, one per subject.
+Context vars: subject_choices (the SUBJECT_CHOICES pairs), subject (the code of the
+page currently being viewed, if any).
+{% endcomment %}
+{% for code, name in subject_choices %}
+  <a href="{% url "oime-casual-browse" code %}"
+     class="btn btn-sm {% if code == subject %}btn-primary{% else %}btn-outline-primary{% endif %}">{{ name }}</a>
+{% endfor %}

--- a/tubes/templates/tubes/landing.html
+++ b/tubes/templates/tubes/landing.html
@@ -63,6 +63,9 @@
       In <b>casual mode</b>, you can browse and try whatever problems you like.
       There's an answer checker, but it doesn't store anything
       and there's no timers or locks.
+      You also get a per-subject page listing the full statements of every
+      problem you haven't opened yet, so you can scroll through (say) all the
+      geometry problems and pick one you feel like doing.
     </li>
   </ul>
   <p>

--- a/tubes/templates/tubes/landing.html
+++ b/tubes/templates/tubes/landing.html
@@ -63,9 +63,10 @@
       In <b>casual mode</b>, you can browse and try whatever problems you like.
       There's an answer checker, but it doesn't store anything
       and there's no timers or locks.
-      You also get a per-subject page listing the full statements of every
-      problem you haven't opened yet, so you can scroll through (say) all the
-      geometry problems and pick one you feel like doing.
+      You also get a per-subject page listing the full statement of every
+      problem, so you can scroll through (say) all the geometry problems and
+      pick one you feel like doing.
+      Problems you've already seen are greyed out there.
     </li>
   </ul>
   <p>

--- a/tubes/templates/tubes/proposal_list.html
+++ b/tubes/templates/tubes/proposal_list.html
@@ -21,7 +21,7 @@
         Nothing you do is recorded or timed, so browse as you like.
       </p>
       <p class="text-muted">
-        Read the full statements for one subject:
+        Subject view:
         {% include "tubes/components/casual_subject_nav.html" %}
       </p>
     {% else %}

--- a/tubes/templates/tubes/proposal_list.html
+++ b/tubes/templates/tubes/proposal_list.html
@@ -20,6 +20,10 @@
         You're in <strong>casual mode</strong>.
         Nothing you do is recorded or timed, so browse as you like.
       </p>
+      <p class="text-muted">
+        Read all the statements you haven't seen yet in one subject:
+        {% include "tubes/components/casual_subject_nav.html" %}
+      </p>
     {% else %}
       <p class="text-muted">
         You're testsolving in <strong>ranked mode</strong>.

--- a/tubes/templates/tubes/proposal_list.html
+++ b/tubes/templates/tubes/proposal_list.html
@@ -21,7 +21,7 @@
         Nothing you do is recorded or timed, so browse as you like.
       </p>
       <p class="text-muted">
-        Read all the statements you haven't seen yet in one subject:
+        Read the full statements for one subject:
         {% include "tubes/components/casual_subject_nav.html" %}
       </p>
     {% else %}

--- a/tubes/tests.py
+++ b/tubes/tests.py
@@ -719,6 +719,132 @@ def test_casual_revealed_can_comment(otis):
 
 
 # ---------------------------------------------------------------------------
+# Casual full-statement browser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_casual_browse_shows_unspoiled_statements_of_one_subject(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    wanted = OIMEProposalFactory.create(subject="G", statement="Geometry statement.")
+    other_subject = OIMEProposalFactory.create(subject="N", statement="Number theory.")
+    otis.login(user)
+    resp = otis.get_20x("oime-casual-browse", "G")
+    otis.assert_has(resp, "Geometry statement.")
+    otis.assert_not_has(resp, "Number theory.")
+    otis.assert_has(resp, wanted.label)
+    otis.assert_not_has(resp, other_subject.label)
+
+
+@pytest.mark.django_db
+def test_casual_browse_never_shows_answers_or_solutions(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    OIMEProposalFactory.create(subject="A", answer=123, solution="Secret solution.")
+    otis.login(user)
+    resp = otis.get_20x("oime-casual-browse", "A")
+    otis.assert_not_has(resp, "Secret solution.")
+    otis.assert_not_has(resp, "oime-answer-section")
+
+
+@pytest.mark.django_db
+def test_casual_browse_omits_spoiled_problems(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    own = OIMEProposalFactory.create(
+        author=contributor, subject="C", statement="I wrote this."
+    )
+    revealed = OIMEProposalFactory.create(subject="C", statement="Already revealed.")
+    contributor.revealed_proposals.add(revealed)
+    fought = OIMEProposalFactory.create(subject="C", statement="Already fought.")
+    OIMEFightFactory.create(
+        contributor=contributor, proposal=fought, status="OIME_FAIL"
+    )
+    fresh = OIMEProposalFactory.create(subject="C", statement="Brand new one.")
+    otis.login(user)
+    resp = otis.get_20x("oime-casual-browse", "C")
+    otis.assert_has(resp, "Brand new one.")
+    for proposal in (own, revealed, fought):
+        otis.assert_not_has(resp, proposal.statement)
+    assert list(resp.context["proposals"]) == [fresh]
+
+
+@pytest.mark.django_db
+def test_casual_browse_hides_archived_and_drafts(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    OIMEProposalFactory.create(subject="N", archived=True, statement="Archived one.")
+    OIMEProposalFactory.create(subject="N", is_draft=True, statement="Draft one.")
+    otis.login(user)
+    resp = otis.get_20x("oime-casual-browse", "N")
+    otis.assert_not_has(resp, "Archived one.")
+    otis.assert_not_has(resp, "Draft one.")
+
+
+@pytest.mark.django_db
+def test_casual_browse_orders_by_difficulty(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    hard = OIMEProposalFactory.create(subject="A", difficulty=5)
+    easy = OIMEProposalFactory.create(subject="A", difficulty=1)
+    medium = OIMEProposalFactory.create(subject="A", difficulty=3)
+    otis.login(user)
+    resp = otis.get_20x("oime-casual-browse", "A")
+    assert list(resp.context["proposals"]) == [easy, medium, hard]
+
+
+@pytest.mark.django_db
+def test_casual_browse_refused_in_ranked_mode(otis):
+    # Ranked statements are meant to be read for the first time under the clock.
+    user, _ = _verified_contributor()
+    OIMEProposalFactory.create(subject="G", statement="Geometry statement.")
+    otis.login(user)
+    resp = otis.get("oime-casual-browse", "G")
+    otis.assert_30x(resp)
+    assert resp.url.endswith("/tubes/proposals/")
+
+
+@pytest.mark.django_db
+def test_casual_browse_rejects_unknown_subject(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    otis.login(user)
+    otis.get_not_found("oime-casual-browse", "Z")
+
+
+@pytest.mark.django_db
+def test_casual_browse_requires_verification(otis):
+    UserFactory.create(username="mallory")
+    otis.login("mallory")
+    otis.get_40x("oime-casual-browse", "G")
+
+
+@pytest.mark.django_db
+def test_casual_list_links_to_browser(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    otis.login(user)
+    resp = otis.get_20x("oime-proposal-list")
+    otis.assert_has(resp, "/tubes/casual/G/")
+
+
+@pytest.mark.django_db
+def test_ranked_list_does_not_link_to_browser(otis):
+    user, _ = _verified_contributor()
+    otis.login(user)
+    resp = otis.get_20x("oime-proposal-list")
+    otis.assert_not_has(resp, "/tubes/casual/G/")
+
+
+# ---------------------------------------------------------------------------
 # Timed solve flow
 # ---------------------------------------------------------------------------
 

--- a/tubes/tests.py
+++ b/tubes/tests.py
@@ -724,7 +724,7 @@ def test_casual_revealed_can_comment(otis):
 
 
 @pytest.mark.django_db
-def test_casual_browse_shows_unspoiled_statements_of_one_subject(otis):
+def test_casual_browse_shows_statements_of_one_subject(otis):
     user, contributor = _verified_contributor()
     contributor.casual_mode = True
     contributor.save()
@@ -751,26 +751,38 @@ def test_casual_browse_never_shows_answers_or_solutions(otis):
 
 
 @pytest.mark.django_db
-def test_casual_browse_omits_spoiled_problems(otis):
+def test_casual_browse_includes_spoiled_problems_but_marks_them(otis):
     user, contributor = _verified_contributor()
     contributor.casual_mode = True
     contributor.save()
+    fresh = OIMEProposalFactory.create(subject="C", statement="Brand new one.")
     own = OIMEProposalFactory.create(
         author=contributor, subject="C", statement="I wrote this."
     )
     revealed = OIMEProposalFactory.create(subject="C", statement="Already revealed.")
     contributor.revealed_proposals.add(revealed)
-    fought = OIMEProposalFactory.create(subject="C", statement="Already fought.")
+    solved = OIMEProposalFactory.create(subject="C", statement="Already solved.")
+    OIMEFightFactory.create(contributor=contributor, proposal=solved, status="OIME_OK")
+    gave_up = OIMEProposalFactory.create(subject="C", statement="Already gave up.")
     OIMEFightFactory.create(
-        contributor=contributor, proposal=fought, status="OIME_FAIL"
+        contributor=contributor, proposal=gave_up, status="OIME_FAIL"
     )
-    fresh = OIMEProposalFactory.create(subject="C", statement="Brand new one.")
     otis.login(user)
     resp = otis.get_20x("oime-casual-browse", "C")
-    otis.assert_has(resp, "Brand new one.")
-    for proposal in (own, revealed, fought):
-        otis.assert_not_has(resp, proposal.statement)
-    assert list(resp.context["proposals"]) == [fresh]
+    # Every problem is listed, statement and all...
+    for proposal in (fresh, own, revealed, solved, gave_up):
+        otis.assert_has(resp, proposal.statement)
+    # ...but each is labelled by how the viewer has already engaged with it.
+    statuses = {p.pk: p.browse_status for p in resp.context["page_obj"]}
+    assert statuses == {
+        fresh.pk: "new",
+        own.pk: "author",
+        revealed.pk: "revealed",
+        solved.pk: "solved",
+        gave_up.pk: "attempted",
+    }
+    spoiled = {p.pk for p in resp.context["page_obj"] if p.spoiled}
+    assert spoiled == {own.pk, revealed.pk, solved.pk, gave_up.pk}
 
 
 @pytest.mark.django_db
@@ -780,23 +792,64 @@ def test_casual_browse_hides_archived_and_drafts(otis):
     contributor.save()
     OIMEProposalFactory.create(subject="N", archived=True, statement="Archived one.")
     OIMEProposalFactory.create(subject="N", is_draft=True, statement="Draft one.")
+    # Even the viewer's own draft stays out; drafts live on the drafts page only.
+    OIMEProposalFactory.create(
+        author=contributor, subject="N", is_draft=True, statement="My draft."
+    )
     otis.login(user)
     resp = otis.get_20x("oime-casual-browse", "N")
     otis.assert_not_has(resp, "Archived one.")
     otis.assert_not_has(resp, "Draft one.")
+    otis.assert_not_has(resp, "My draft.")
 
 
 @pytest.mark.django_db
-def test_casual_browse_orders_by_difficulty(otis):
+def test_casual_browse_orders_newest_first(otis):
     user, contributor = _verified_contributor()
     contributor.casual_mode = True
     contributor.save()
-    hard = OIMEProposalFactory.create(subject="A", difficulty=5)
-    easy = OIMEProposalFactory.create(subject="A", difficulty=1)
-    medium = OIMEProposalFactory.create(subject="A", difficulty=3)
+    oldest = OIMEProposalFactory.create(subject="A")
+    middle = OIMEProposalFactory.create(subject="A")
+    newest = OIMEProposalFactory.create(subject="A")
     otis.login(user)
     resp = otis.get_20x("oime-casual-browse", "A")
-    assert list(resp.context["proposals"]) == [easy, medium, hard]
+    assert list(resp.context["page_obj"]) == [newest, middle, oldest]
+
+
+@pytest.mark.django_db
+def test_casual_browse_paginates(otis):
+    from .views import CASUAL_BROWSE_PAGE_SIZE
+
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    proposals = [
+        OIMEProposalFactory.create(subject="G")
+        for _ in range(CASUAL_BROWSE_PAGE_SIZE + 3)
+    ]
+    otis.login(user)
+    resp = otis.get_20x("oime-casual-browse", "G")
+    page_obj = resp.context["page_obj"]
+    assert page_obj.paginator.num_pages == 2
+    assert len(page_obj.object_list) == CASUAL_BROWSE_PAGE_SIZE
+    assert list(page_obj) == list(reversed(proposals))[:CASUAL_BROWSE_PAGE_SIZE]
+    resp = otis.get_20x("oime-casual-browse", "G", data={"page": 2})
+    page_obj = resp.context["page_obj"]
+    assert list(page_obj) == list(reversed(proposals))[CASUAL_BROWSE_PAGE_SIZE:]
+    # Statuses are still computed on later pages.
+    assert all(p.browse_status == "new" for p in page_obj)
+
+
+@pytest.mark.django_db
+def test_casual_browse_bad_page_falls_back_to_first(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    OIMEProposalFactory.create(subject="G")
+    otis.login(user)
+    for bad_page in ("0", "99", "banana"):
+        resp = otis.get_20x("oime-casual-browse", "G", data={"page": bad_page})
+        assert resp.context["page_obj"].number == 1
 
 
 @pytest.mark.django_db

--- a/tubes/urls.py
+++ b/tubes/urls.py
@@ -35,6 +35,11 @@ urlpatterns = [
     path(r"comment/<int:pk>/edit/", views.edit_comment, name="oime-comment-edit"),
     path(r"setup/", views.oime_setup, name="oime-setup"),
     path(r"casual/", views.go_casual, name="oime-casual"),
+    path(
+        r"casual/<str:subject>/",
+        views.casual_browse,
+        name="oime-casual-browse",
+    ),
     path(r"serious/", views.go_serious, name="oime-serious"),
     path(r"", views.LandingView.as_view(), name="oime-landing"),
 ]

--- a/tubes/views.py
+++ b/tubes/views.py
@@ -5,6 +5,7 @@ from typing import Any
 from django import forms
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
+from django.core.paginator import Paginator
 from django.db.models import Count
 from django.db.models.query import QuerySet
 from django.http import Http404, HttpRequest, HttpResponse
@@ -27,6 +28,7 @@ SUBJECT_NAMES = dict(OIMEProposal.SUBJECT_CHOICES)
 
 GIVE_UP_RATE_LIMIT = 2  # max give-ups allowed within the window
 GIVE_UP_WINDOW_MINUTES = 10
+CASUAL_BROWSE_PAGE_SIZE = 20
 
 
 def _get_contributor(request: HttpRequest) -> OIMEContributor | None:
@@ -255,13 +257,13 @@ def go_serious(request: HttpRequest) -> HttpResponse:
 
 @verified_required
 def casual_browse(request: HttpRequest, subject: str) -> HttpResponse:
-    """Every unspoiled statement in one subject, on a single scrollable page.
+    """Every visible statement in one subject, newest first, in pages of 20.
 
     Casual mode only. The point of ranked mode is that a statement is seen for the
     first time under the clock, so bulk-reading statements would defeat it; in casual
     mode nothing is timed or recorded, so browsing for a problem to try is the whole
-    idea. "Unspoiled" here means the contributor has not engaged with the problem at
-    all: not their own, not revealed, and never fought.
+    idea. Every problem the contributor may see is listed, their own included; the
+    ones already spoiled for them are just marked as such.
     """
     if subject not in SUBJECT_NAMES:
         raise Http404("Not an OIME subject.")
@@ -277,19 +279,48 @@ def casual_browse(request: HttpRequest, subject: str) -> HttpResponse:
 
     proposals = (
         OIMEProposal.objects.filter(archived=False, is_draft=False, subject=subject)
-        .exclude(author=contributor)
-        .exclude(pk__in=contributor.revealed_proposals.values("pk"))
-        .exclude(fights__contributor=contributor)
         .select_related("author")
         .annotate(upvote_count=Count("upvotes", distinct=True))
-        .order_by("difficulty", "-created_at")
+        .order_by("-pk")
     )
+    paginator = Paginator(proposals, CASUAL_BROWSE_PAGE_SIZE)
+    page_obj = paginator.get_page(request.GET.get("page"))
+
+    # Flag the problems this contributor has already engaged with, so a page of
+    # statements shows at a glance which ones are still fresh. Only the current
+    # page is inspected, so this stays cheap however long the subject list grows.
+    page_proposals = list(page_obj.object_list)
+    fights: dict[int, OIMEFight] = {
+        f.proposal_id: f  # type: ignore[attr-defined]
+        for f in OIMEFight.objects.filter(
+            contributor=contributor, proposal__in=page_proposals
+        )
+    }
+    revealed_ids = set(
+        contributor.revealed_proposals.filter(
+            pk__in=[p.pk for p in page_proposals]
+        ).values_list("pk", flat=True)
+    )
+    for proposal in page_proposals:
+        fight = fights.get(proposal.pk)
+        if proposal.author == contributor:
+            proposal.browse_status = "author"  # type: ignore[attr-defined]
+        elif fight is not None:
+            proposal.browse_status = (  # type: ignore[attr-defined]
+                "solved" if fight.is_success else "attempted"
+            )
+        elif proposal.pk in revealed_ids:
+            proposal.browse_status = "revealed"  # type: ignore[attr-defined]
+        else:
+            proposal.browse_status = "new"  # type: ignore[attr-defined]
+        proposal.spoiled = proposal.browse_status != "new"  # type: ignore[attr-defined]
+    page_obj.object_list = page_proposals
 
     return render(
         request,
         "tubes/casual_browse.html",
         {
-            "proposals": proposals,
+            "page_obj": page_obj,
             "contributor": contributor,
             "subject": subject,
             "subject_name": SUBJECT_NAMES[subject],

--- a/tubes/views.py
+++ b/tubes/views.py
@@ -7,7 +7,7 @@ from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count
 from django.db.models.query import QuerySet
-from django.http import HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views.generic import CreateView, ListView, TemplateView, UpdateView
@@ -22,6 +22,8 @@ from .forms import (
     OIMEProposalForm,
 )
 from .models import OIMEComment, OIMEContributor, OIMEFight, OIMEProposal
+
+SUBJECT_NAMES = dict(OIMEProposal.SUBJECT_CHOICES)
 
 GIVE_UP_RATE_LIMIT = 2  # max give-ups allowed within the window
 GIVE_UP_WINDOW_MINUTES = 10
@@ -251,6 +253,51 @@ def go_serious(request: HttpRequest) -> HttpResponse:
     )
 
 
+@verified_required
+def casual_browse(request: HttpRequest, subject: str) -> HttpResponse:
+    """Every unspoiled statement in one subject, on a single scrollable page.
+
+    Casual mode only. The point of ranked mode is that a statement is seen for the
+    first time under the clock, so bulk-reading statements would defeat it; in casual
+    mode nothing is timed or recorded, so browsing for a problem to try is the whole
+    idea. "Unspoiled" here means the contributor has not engaged with the problem at
+    all: not their own, not revealed, and never fought.
+    """
+    if subject not in SUBJECT_NAMES:
+        raise Http404("Not an OIME subject.")
+    contributor = _get_contributor(request)
+    if contributor is None:
+        return redirect("oime-setup")
+    if not contributor.casual_mode:
+        messages.error(
+            request,
+            "Browsing problem statements in bulk is only available in casual mode.",
+        )
+        return redirect("oime-proposal-list")
+
+    proposals = (
+        OIMEProposal.objects.filter(archived=False, is_draft=False, subject=subject)
+        .exclude(author=contributor)
+        .exclude(pk__in=contributor.revealed_proposals.values("pk"))
+        .exclude(fights__contributor=contributor)
+        .select_related("author")
+        .annotate(upvote_count=Count("upvotes", distinct=True))
+        .order_by("difficulty", "-created_at")
+    )
+
+    return render(
+        request,
+        "tubes/casual_browse.html",
+        {
+            "proposals": proposals,
+            "contributor": contributor,
+            "subject": subject,
+            "subject_name": SUBJECT_NAMES[subject],
+            "subject_choices": OIMEProposal.SUBJECT_CHOICES,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # OIME: Proposal list / create / update
 # ---------------------------------------------------------------------------
@@ -292,6 +339,7 @@ class ProposalListView(ContributorRequiredMixin, ListView[OIMEProposal]):
             return context
 
         context["casual"] = contributor.casual_mode
+        context["subject_choices"] = OIMEProposal.SUBJECT_CHOICES
 
         user_fights: dict[int, OIMEFight] = {
             f.proposal_id: f  # type: ignore[attr-defined]


### PR DESCRIPTION
Adds /tubes/casual/<subject>/, a casual-only page that renders every unspoiled problem in one subject (A, C, G, N) as a scrollable list of cards: label, title, heart count, fire rating, link, and the statement itself. The intent is browsing for something to try, so it is ordered easiest first rather than newest first.

"Unspoiled" mirrors the main list's casual bucket: not archived, not a draft, not authored by the viewer, not revealed, and never fought.

Ranked mode is redirected back to the proposal list with a message, since the whole point there is seeing a statement for the first time under the clock. The subject links only appear on the proposal list while in casual mode.