### PR TITLE
fix: how can default charset not be UTF8 wtf

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -52,7 +52,7 @@ def get_protected_file(
             f'{"inline" if inline_pdf else "attachment"}; filename="{filename}"'
         )
     else:
-        response["Content-Type"] = "text/plain"
+        response["Content-Type"] = "text/plain; charset=utf-8"
         response["Content-Disposition"] = (
             f'{"inline" if inline_tex else "attachment"}; filename="{filename}"'
         )


### PR DESCRIPTION
It's correct on disk:

```
$ sed '550q;d' BAX-tex-genfunc.tex 
\begin{problem}[Paul Erdős, $5\clubsuit$]

$ sed '550q;d' BAX-tex-genfunc.tex | xxd
00000000: 5c62 6567 696e 7b70 726f 626c 656d 7d5b  \begin{problem}[
00000010: 5061 756c 2045 7264 c591 732c 2024 355c  Paul Erd..s, $5\
00000020: 636c 7562 7375 6974 245d 0a              clubsuit$].
```

But apparently browsers assume Latin-1? so Erdős -> ErdÅs? smh