### PR TITLE
fix: build GitHub issue list with DOM nodes instead of HTML strings

### DIFF
--- a/rpg/templates/rpg/github_landing.html
+++ b/rpg/templates/rpg/github_landing.html
@@ -34,10 +34,53 @@
   </p>
   <div id="github-issues-list"></div>
   <script type="text/javascript">
+      const REPO_URL = 'https://github.com/vEnhance/otis-web';
+
       const create_label_url = (label) => {
-          let url = new URL('https://github.com/vEnhance/otis-web/issues');
+          let url = new URL(`${REPO_URL}/issues`);
           url.searchParams.set('q', `is:issue is:open label:"${label.name}"`);
-          return url;
+          return url.href;
+      };
+
+      // Remote GitHub data is never interpolated into markup: every string from
+      // the API is set with textContent or through a property assignment, so a
+      // hostile issue title or label name stays inert text.
+      const create_label_link = (label) => {
+          const link = document.createElement('a');
+          link.href = create_label_url(label);
+          const sup = document.createElement('sup');
+          if (/^[0-9a-fA-F]{6}$/.test(label.color ?? '')) {
+              sup.style.color = `#${label.color}`;
+          }
+          sup.textContent = label.name;
+          link.appendChild(sup);
+          return link;
+      };
+
+      const create_issue_paragraph = (issue) => {
+          const number = Number(issue.number);
+          if (!Number.isInteger(number)) {
+              return null;
+          }
+          const paragraph = document.createElement('p');
+
+          const strong = document.createElement('strong');
+          const number_link = document.createElement('a');
+          number_link.href = `${REPO_URL}/issues/${number}`;
+          number_link.textContent = `#${number}`;
+          strong.appendChild(number_link);
+          paragraph.appendChild(strong);
+
+          paragraph.appendChild(document.createTextNode(`. ${issue.title}`));
+
+          (issue.labels ?? []).forEach((label, i) => {
+              if (i > 0) {
+                  paragraph.appendChild(document.createTextNode(' '));
+              }
+              paragraph.appendChild(create_label_link(label));
+          });
+
+          return paragraph;
       };
 
       // https://stackoverflow.com/a/26608674/4826845
@@ -47,21 +90,17 @@
           let allIssues = await result.json();
 
           allIssues = allIssues.filter(issue => !issue.pull_request);
-          console.log(allIssues);
           allIssues.sort(() => 0.5 - Math.random()); // random order
           const sliceOfIssues = allIssues.slice(0, 5);
 
           // ... only in JavaScript does .sort() assume strings huh
           sliceOfIssues.sort((issue1, issue2) => issue1.number - issue2.number);
-          sliceOfIssues.slice(0, 5).forEach(issue => {
-              console.log(issue);
-              let issue_url = `https://github.com/vEnhance/otis-web/issues/${issue.number}`;
-              let item = `<p>`;
-              item += `<strong><a href="${issue_url}">#${issue.number}</a></strong>. `;
-              item += `${issue.title}`;
-              item += issue.labels.map(label => `<a href="${create_label_url(label)}"><sup style="color:#${label.color};">${label.name}</sup></a>`).join(' ');
-              item += `</p>`;
-              $("#github-issues-list").append(item);
+          const list = document.getElementById("github-issues-list");
+          sliceOfIssues.forEach(issue => {
+              const paragraph = create_issue_paragraph(issue);
+              if (paragraph !== null) {
+                  list.appendChild(paragraph);
+              }
           });
       });
   </script>


### PR DESCRIPTION
Bug fix (cross-site scripting), from a security review of the repository.

The GitHub landing page fetches open issues from `api.github.com` and used to concatenate `issue.title`, `label.name`, and `label.color` into an HTML string that was handed to jQuery `append()`, which parses it as markup. Anyone able to open an issue on the repo could therefore run same-origin JavaScript in the browser of any visitor who happened to get that issue in the random five-issue slice.

Each issue is now assembled with `document.createElement`, and every string coming from the API is set through `textContent`, so it stays inert text:

- `issue.title` and `label.name` go in via `textContent`.
- `label.color` was interpolated into a `style="color:#…"` attribute; it is now applied to `sup.style.color` only when it matches six hex digits.
- `issue.number` is coerced to an integer before it goes into the issue URL and link text.
- `create_label_url` still builds the query through `URLSearchParams`, and the result is assigned to `href` as a property rather than concatenated.

Two incidental cleanups in the same block: the two leftover `console.log` calls that dumped the fetched issue payloads are gone, as is a redundant second `.slice(0, 5)` on an already-sliced array. The rendered output is otherwise unchanged.

Checked with `make fmt` (djlint clean) and `make test`. Note that the changed code is client-side and the repo has no JS test setup, so the existing `test_github_landing` covers only the Django context, not this logic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01675RPzfCV5n9HTLU5bkkEQ)_