### PR TITLE
fix(roster): only admins can use invoice updateview

### DIFF
--- a/roster/templates/roster/invoice.html
+++ b/roster/templates/roster/invoice.html
@@ -83,10 +83,10 @@
         {% if student.semester.most_payment_deadline %}<li>{{ student.semester.most_payment_deadline|date }}</li>{% endif %}
       </ul>
     {% endif %}
-    {% if request.user.is_staff %}
+    {% if request.user.is_superuser %}
       <ul>
-        <li>
-          (Staff) <a href="{% url "edit-invoice" invoice.pk %}">Edit invoice</a>
+        <li data-testid="edit-invoice-link">
+          (Admin) <a href="{% url "edit-invoice" invoice.pk %}">Edit invoice</a>
         </li>
       </ul>
     {% endif %}

--- a/roster/tests.py
+++ b/roster/tests.py
@@ -1300,12 +1300,37 @@ def test_delinquency_for_joining_second_semester(otis) -> None:
 @pytest.mark.django_db
 def test_update_invoice(otis) -> None:
     firefly: Assistant = AssistantFactory.create()
-    alice: Student = StudentFactory.create(assistant=firefly)
-    invoice: Invoice = InvoiceFactory.create(student=alice)
+    alice: Student = StudentFactory.create(
+        assistant=firefly, semester__show_invoices=True
+    )
+    invoice: Invoice = InvoiceFactory.create(student=alice, total_paid=0)
+
+    # staff who aren't superusers can see the invoice, but can't edit it
     otis.login(firefly)
-    otis.get_20x("edit-invoice", alice.pk)
+    otis.assert_no_testid(otis.get_20x("invoice", alice.pk), "edit-invoice-link")
+    otis.get_denied("edit-invoice", invoice.pk)
+    otis.post_denied(
+        "edit-invoice",
+        invoice.pk,
+        data={
+            "preps_taught": 2,
+            "hours_taught": 8.4,
+            "adjustment": 0,
+            "extras": 0,
+            "total_paid": 1337,
+            "credits": 0,
+        },
+    )
+    invoice.refresh_from_db()
+    assert invoice.total_paid == 0
+
+    # superusers get the edit link and can actually edit
+    admin: User = UserFactory.create(is_staff=True, is_superuser=True)
+    otis.login(admin)
+    otis.assert_testid(otis.get_20x("invoice", alice.pk), "edit-invoice-link")
+    otis.get_20x("edit-invoice", invoice.pk)
     otis.post_redirects(
-        otis.url("invoice", invoice.pk),
+        otis.url("invoice", alice.pk),
         "edit-invoice",
         invoice.pk,
         data={
@@ -1317,6 +1342,9 @@ def test_update_invoice(otis) -> None:
             "credits": 0,
         },
     )
+    invoice.refresh_from_db()
+    assert invoice.preps_taught == 2
+    assert invoice.total_paid == 1152
 
 
 @pytest.mark.django_db

--- a/roster/views.py
+++ b/roster/views.py
@@ -47,7 +47,11 @@ from prettytable import PrettyTable
 from core.models import EMAIL_PREFERENCE_FIELDS, Semester, Unit, UserProfile
 from dashboard.models import PSet
 from otisweb.decorators import admin_required, staff_required
-from otisweb.mixins import StaffRequiredMixin, VerifiedRequiredMixin
+from otisweb.mixins import (
+    AdminRequiredMixin,
+    StaffRequiredMixin,
+    VerifiedRequiredMixin,
+)
 from otisweb.utils import AuthHttpRequest
 from roster.forms import LinkAssistantForm
 from roster.models import ApplyUUID, Assistant
@@ -249,7 +253,7 @@ def master_schedule(request: HttpRequest) -> HttpResponse:
 
 class UpdateInvoice(
     LoginRequiredMixin,
-    StaffRequiredMixin,
+    AdminRequiredMixin,
     UpdateView[Invoice, BaseModelForm[Invoice]],
 ):
     model = Invoice


### PR DESCRIPTION
## Description

This change restricts invoice editing permissions to superusers only, rather than allowing all staff members to edit invoices.

### Changes Made

**Enhancement/Security Fix**

- **views.py**: Changed `UpdateInvoice` view from `StaffRequiredMixin` to `AdminRequiredMixin` to require superuser status for editing invoices
- **templates/roster/invoice.html**: Updated the edit invoice link to only display for superusers (changed `is_staff` check to `is_superuser`) and updated the label from "(Staff)" to "(Admin)"
- **tests.py**: Expanded `test_update_invoice` to verify the new permission model:
  - Non-superuser staff can view invoices but cannot access or edit them
  - Superusers can view the edit link and successfully edit invoices
  - Added assertions to verify invoice data is not modified by unauthorized users and is correctly updated by superusers

### Test Coverage

The existing test `test_update_invoice` has been expanded to cover both permission scenarios and verify that the access control is properly enforced at both the view and template levels.

https://claude.ai/code/session_01NpFmGaagfNM9NYCSpZQ4hW