### PR TITLE
fix: wtf is a race condition

### DIFF
--- a/opal/tests.py
+++ b/opal/tests.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from unittest import mock
 
 import pytest
 from django.contrib.messages import constants as message_levels
@@ -11,7 +12,7 @@ from opal.factories import OpalAttemptFactory, OpalHuntFactory, OpalPuzzleFactor
 from rpg.factories import AchievementFactory
 from rpg.models import AchievementUnlock
 
-from .models import answerize, puzzle_file_name
+from .models import OpalAttempt, answerize, puzzle_file_name
 
 UTC = datetime.UTC
 
@@ -682,3 +683,29 @@ def test_close_answer(otis):
     )
     # a correct-but-not-final guess is acknowledged without solving the puzzle
     assert any(m.level == message_levels.WARNING for m in resp.context["messages"])
+
+
+@pytest.mark.django_db
+def test_guess_budget_is_rechecked_under_the_lock(otis):
+    """A guess that stops being eligible while it waits for the lock is refused.
+
+    The first `_can_attempt` is the optimistic check that decides whether to show
+    the form; the second runs holding the puzzle row. A guess submitted in
+    parallel that used up the last of the budget in between shows up here as the
+    two disagreeing, and the later guess must not be evaluated.
+    """
+    verified_group = GroupFactory(name="Verified")
+    alice = UserFactory.create(username="alice", groups=(verified_group,))
+    otis.login(alice)
+
+    hunt = OpalHuntFactory.create(slug="hunt")
+    puzzle = OpalPuzzleFactory.create(
+        slug="one", answer="1", hunt=hunt, num_to_unlock=0, guess_limit=3
+    )
+
+    with mock.patch("opal.views._can_attempt", side_effect=[True, False]):
+        otis.post_40x(
+            "opal-show-puzzle", "hunt", "one", data={"guess": "1"}, follow=True
+        )
+
+    assert not OpalAttempt.objects.filter(puzzle=puzzle, user=alice).exists()

--- a/opal/views.py
+++ b/opal/views.py
@@ -7,6 +7,7 @@ from allauth.socialaccount.models import SocialAccount
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.db.models import Q
 from django.db.models.aggregates import Max
 from django.db.models.manager import Manager
@@ -226,6 +227,27 @@ def _discord_send_congratulations(request: AuthHttpRequest, hunt: OpalHunt):
     requests.post(url=hunt.discord_webhook_url, json={"content": message})
 
 
+def _incorrect_attempts(puzzle: OpalPuzzle, user: User) -> QuerySet[OpalAttempt]:
+    """The attempts by `user` that count against the guess limit on `puzzle`."""
+    return OpalAttempt.objects.filter(
+        puzzle=puzzle,
+        user=user,
+        excused=False,
+        is_close=False,
+        is_correct=False,
+    ).order_by("-created_at")
+
+
+def _can_attempt(puzzle: OpalPuzzle, user: User) -> bool:
+    """Whether `user` has a guess left on `puzzle` and hasn't already solved it."""
+    is_solved = OpalAttempt.objects.filter(
+        puzzle=puzzle, user=user, is_correct=True
+    ).exists()
+    return (
+        not is_solved and _incorrect_attempts(puzzle, user).count() < puzzle.guess_limit
+    )
+
+
 @verified_required
 def show_puzzle(
     request: AuthHttpRequest, hunt_slug: str, puzzle_slug: str
@@ -240,28 +262,33 @@ def show_puzzle(
                 "Warning: this puzzle isn't unlocked yet. Showing for testsolvers and admins only.",
             )
 
-    past_attempts = OpalAttempt.objects.filter(puzzle=puzzle, user=request.user)
-    is_solved = past_attempts.filter(is_correct=True).exists()
-    incorrect_attempts = OpalAttempt.objects.filter(
-        puzzle=puzzle,
-        user=request.user,
-        excused=False,
-        is_close=False,
-        is_correct=False,
-    ).order_by("-created_at")
-    can_attempt = not is_solved and incorrect_attempts.count() < puzzle.guess_limit
+    is_solved = OpalAttempt.objects.filter(
+        puzzle=puzzle, user=request.user, is_correct=True
+    ).exists()
+    incorrect_attempts = _incorrect_attempts(puzzle, request.user)
+    can_attempt = _can_attempt(puzzle, request.user)
 
     if request.method == "POST":
         if not can_attempt:
             raise PermissionDenied("You cannot attempt this puzzle anymore.")
         form = AttemptForm(request.POST)
         if form.is_valid():
-            attempt = OpalAttempt(
-                guess=form.cleaned_data["guess"],
-                user=request.user,
-                puzzle=puzzle,
-            )
-            attempt.save()
+            # Hold the puzzle row while the guess budget is rechecked and the
+            # attempt is written. Without it, guesses submitted in parallel all
+            # read the same remaining count and all get evaluated, so the limit
+            # can be overrun. Keep this block short and free of network calls:
+            # everything else on this puzzle waits behind the lock until it
+            # commits, so the Discord ping below stays outside it.
+            with transaction.atomic():
+                puzzle = OpalPuzzle.objects.select_for_update().get(pk=puzzle.pk)
+                if not _can_attempt(puzzle, request.user):
+                    raise PermissionDenied("You cannot attempt this puzzle anymore.")
+                attempt = OpalAttempt(
+                    guess=form.cleaned_data["guess"],
+                    user=request.user,
+                    puzzle=puzzle,
+                )
+                attempt.save()
             if attempt.is_correct:
                 solve_message = f"Correct answer to {puzzle.title}!"
                 messages.success(request, solve_message)

--- a/payments/views.py
+++ b/payments/views.py
@@ -372,33 +372,43 @@ def job_claim(request: HttpRequest, pk: int) -> HttpResponse:
         messages.error(request, "You need to set up a work profile first")
         return HttpResponseRedirect(reverse("worker-update"))
     else:
-        job: Job = Job.objects.get(pk=pk)
-        jobfolder: JobFolder = job.folder
-        jobs_already_claimed = Job.objects.filter(folder=jobfolder, assignee=worker)
+        # Both the quotas and "is this job still free" are check-then-act, so the
+        # whole claim runs in one transaction. Locking the worker serializes that
+        # worker's own claims against each other, which is what the per-folder
+        # quotas are counting; locking the job settles two workers racing for the
+        # same one. This is the only place that takes both, so the order of the
+        # two can't cycle with anything.
+        with transaction.atomic():
+            Worker.objects.select_for_update().get(pk=worker.pk)
+            job: Job = Job.objects.select_for_update().get(pk=pk)
+            jobfolder: JobFolder = job.folder
+            jobs_already_claimed = Job.objects.filter(folder=jobfolder, assignee=worker)
 
-        if job.assignee is not None:
-            messages.error(request, "This task is already claimed.")
-        elif (
-            jobfolder.max_pending is not None
-            and jobs_already_claimed.exclude(progress="JOB_VFD").count()
-            >= jobfolder.max_pending
-        ):
-            messages.error(
-                request,
-                "You already reached the maximum number of pending tasks for this category.",
-            )
-        elif (
-            jobfolder.max_total is not None
-            and jobs_already_claimed.count() >= jobfolder.max_total
-        ):
-            messages.error(
-                request,
-                "You already reached the maximum number of total tasks for this category.",
-            )
-        else:
-            job.assignee = worker
-            job.save()
-            messages.success(request, f"You have successfully claimed task #{job.pk}.")
+            if job.assignee is not None:
+                messages.error(request, "This task is already claimed.")
+            elif (
+                jobfolder.max_pending is not None
+                and jobs_already_claimed.exclude(progress="JOB_VFD").count()
+                >= jobfolder.max_pending
+            ):
+                messages.error(
+                    request,
+                    "You already reached the maximum number of pending tasks for this category.",
+                )
+            elif (
+                jobfolder.max_total is not None
+                and jobs_already_claimed.count() >= jobfolder.max_total
+            ):
+                messages.error(
+                    request,
+                    "You already reached the maximum number of total tasks for this category.",
+                )
+            else:
+                job.assignee = worker
+                job.save()
+                messages.success(
+                    request, f"You have successfully claimed task #{job.pk}."
+                )
         return HttpResponseRedirect(job.get_absolute_url())
 
 

--- a/roster/tests.py
+++ b/roster/tests.py
@@ -2,6 +2,7 @@ import datetime
 import re
 from decimal import Decimal
 from io import StringIO
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -1895,3 +1896,58 @@ def test_student_ids(otis) -> None:
     otis.login(bob)
     resp = otis.get_20x("student-ids")
     assert list(resp.context["students"]) == [bob_student]
+
+
+@pytest.mark.django_db
+def test_registration_is_all_or_nothing(otis) -> None:
+    """A failure partway through redemption leaves the passcode unspent.
+
+    Redemption saves the registration, claims the ApplyUUID, rewrites the user's
+    name and email, and builds the student and invoice. Those now happen in one
+    transaction, so a failure in the middle can't burn a passcode without
+    producing the student it was supposed to pay for.
+    """
+    au = ApplyUUIDFactory.create(percent_aid=0)
+    semester: Semester = SemesterFactory.create()
+    container: RegistrationContainer = RegistrationContainerFactory.create(
+        semester=semester, accepting_responses=True
+    )
+    alice: User = UserFactory.create(first_name="a", last_name="a", email="a@a.net")
+    otis.login(alice)
+
+    agreement = StringIO("agree!")
+    agreement.name = "agreement.pdf"
+
+    with (
+        mock.patch("roster.views.build_student", side_effect=RuntimeError("boom")),
+        pytest.raises(RuntimeError),
+    ):
+        otis.post(
+            "register",
+            data={
+                "given_name": "Alice",
+                "surname": "Aardvark",
+                "email_address": "myemail@example.com",
+                "passcode": au.uuid,
+                "gender": "O",
+                "parent_email": "myemail@example.com",
+                "graduation_year": 0,
+                "school_name": "Generic School District",
+                "country": "USA",
+                "aops_username": "",
+                "agreement_form": agreement,
+                "email_on_announcement": False,
+                "email_on_pset_complete": True,
+                "email_on_suggestion_processed": False,
+                "email_on_inquiry_complete": False,
+            },
+        )
+
+    au.refresh_from_db()
+    assert au.reg is None
+    assert not StudentRegistration.objects.filter(
+        user=alice, container=container
+    ).exists()
+    assert not Student.objects.filter(user=alice).exists()
+    alice.refresh_from_db()
+    assert alice.first_name == "a"

--- a/roster/views.py
+++ b/roster/views.py
@@ -453,34 +453,40 @@ def register(request: AuthHttpRequest) -> HttpResponse:
         if form.is_valid():
             passcode = form.cleaned_data["passcode"]
             try:
-                au = ApplyUUID.objects.get(uuid=passcode)
+                # Redemption runs in one transaction holding the UUID row, so that
+                # two people sent the same passcode can't both find it unused and
+                # each walk away an enrolled student.
+                with atomic():
+                    au = ApplyUUID.objects.select_for_update().get(uuid=passcode)
+                    if au.reg is not None:
+                        raise PermissionDenied("This UUID was already used.")
+                    if not au.enabled:
+                        messages.error(
+                            request,
+                            message="This application has expired. "
+                            "Please contact Evan for more details.",
+                        )
+                        return HttpResponseRedirect(reverse("index"))
+                    registration = form.save(commit=False)
+                    registration.container = container
+                    registration.user = request.user
+                    registration.save()
+                    au.reg = registration
+                    au.save()
+                    request.user.first_name = form.cleaned_data["given_name"].strip()
+                    request.user.last_name = form.cleaned_data["surname"].strip()
+                    request.user.email = form.cleaned_data["email_address"]
+                    request.user.save()
+                    UserProfile.objects.update_or_create(
+                        user=request.user,
+                        defaults={
+                            k: form.cleaned_data[k] for k in EMAIL_PREFERENCE_FIELDS
+                        },
+                    )
+                    build_student(registration)
             except (ApplyUUID.DoesNotExist, ValidationError):
                 messages.error(request, message="Wrong passcode")
             else:
-                if au.reg is not None:
-                    raise PermissionDenied("This UUID was already used.")
-                if not au.enabled:
-                    messages.error(
-                        request,
-                        message="This application has expired. "
-                        "Please contact Evan for more details.",
-                    )
-                    return HttpResponseRedirect(reverse("index"))
-                registration = form.save(commit=False)
-                registration.container = container
-                registration.user = request.user
-                registration.save()
-                au.reg = registration
-                au.save()
-                request.user.first_name = form.cleaned_data["given_name"].strip()
-                request.user.last_name = form.cleaned_data["surname"].strip()
-                request.user.email = form.cleaned_data["email_address"]
-                request.user.save()
-                UserProfile.objects.update_or_create(
-                    user=request.user,
-                    defaults={k: form.cleaned_data[k] for k in EMAIL_PREFERENCE_FIELDS},
-                )
-                build_student(registration)
                 messages.success(
                     request,
                     message="Your registration was accepted! "

--- a/tubes/views.py
+++ b/tubes/views.py
@@ -6,6 +6,7 @@ from django import forms
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
+from django.db import transaction
 from django.db.models import Count
 from django.db.models.query import QuerySet
 from django.http import Http404, HttpRequest, HttpResponse
@@ -637,14 +638,20 @@ def start_fight(request: HttpRequest, pk: int) -> HttpResponse:
         return redirect("oime-proposal-detail", pk)
 
     if request.method == "POST":
-        if OIMEFight.objects.filter(
-            contributor=contributor, status="OIME_TBD"
-        ).exists():
-            messages.error(
-                request, "You already have an active timed session in progress."
-            )
-            return redirect("oime-proposal-detail", pk)
-        OIMEFight.objects.create(contributor=contributor, proposal=proposal)
+        # Hold the contributor row across the check and the create. The unique
+        # constraint on the fight is (contributor, proposal), so it does nothing
+        # to stop starts on two *different* proposals from both finding no active
+        # session and each opening one.
+        with transaction.atomic():
+            OIMEContributor.objects.select_for_update().get(pk=contributor.pk)
+            if OIMEFight.objects.filter(
+                contributor=contributor, status="OIME_TBD"
+            ).exists():
+                messages.error(
+                    request, "You already have an active timed session in progress."
+                )
+                return redirect("oime-proposal-detail", pk)
+            OIMEFight.objects.create(contributor=contributor, proposal=proposal)
         return redirect("oime-proposal-fight", pk)
 
     return render(
@@ -763,46 +770,57 @@ def submit_answer(request: HttpRequest, pk: int) -> HttpResponse:
     if contributor is None:
         return redirect("oime-setup")
 
-    attempt = get_object_or_404(OIMEFight, contributor=contributor, proposal=proposal)
+    # Hold the fight row for the whole adjudication. Answers submitted in
+    # parallel would otherwise all read the same wrong_answers and all judge
+    # against the same not-yet-terminal status, so the increments clobber each
+    # other and more than ANSWER_LIMIT answers get graded.
+    with transaction.atomic():
+        attempt = get_object_or_404(
+            OIMEFight.objects.select_for_update(),
+            contributor=contributor,
+            proposal=proposal,
+        )
 
-    if attempt.status != "OIME_TBD":
-        return redirect("oime-proposal-detail", pk)
+        if attempt.status != "OIME_TBD":
+            return redirect("oime-proposal-detail", pk)
 
-    if attempt.time_expired:
-        attempt.status = "OIME_TLE"
-        attempt.submitted_at = timezone.now()
-        attempt.save()
-        messages.warning(request, "The time limit for your timed session has expired.")
-        return redirect("oime-proposal-detail", pk)
-
-    form = OIMEAnswerForm(request.POST)
-    if not form.is_valid():
-        messages.error(request, "Please enter a valid integer (0-999).")
-        return redirect("oime-proposal-fight", pk)
-
-    submitted = form.cleaned_data["answer"]
-    if submitted == proposal.answer:
-        attempt.status = "OIME_OK"
-        attempt.submitted_at = timezone.now()
-        attempt.save()
-        messages.success(request, f"Correct! You took {attempt.time_display}.")
-    else:
-        attempt.wrong_answers += 1
-        if attempt.wrong_answers >= OIMEFight.ANSWER_LIMIT:
-            attempt.status = "OIME_ALE"
+        if attempt.time_expired:
+            attempt.status = "OIME_TLE"
             attempt.submitted_at = timezone.now()
             attempt.save()
-            messages.error(
-                request,
-                f"Incorrect. You have used all {OIMEFight.ANSWER_LIMIT} attempts.",
+            messages.warning(
+                request, "The time limit for your timed session has expired."
             )
-        else:
+            return redirect("oime-proposal-detail", pk)
+
+        form = OIMEAnswerForm(request.POST)
+        if not form.is_valid():
+            messages.error(request, "Please enter a valid integer (0-999).")
+            return redirect("oime-proposal-fight", pk)
+
+        submitted = form.cleaned_data["answer"]
+        if submitted == proposal.answer:
+            attempt.status = "OIME_OK"
+            attempt.submitted_at = timezone.now()
             attempt.save()
-            remaining = OIMEFight.ANSWER_LIMIT - attempt.wrong_answers
-            messages.error(
-                request,
-                f"Incorrect. {remaining} attempt{'' if remaining == 1 else 's'} remaining.",
-            )
+            messages.success(request, f"Correct! You took {attempt.time_display}.")
+        else:
+            attempt.wrong_answers += 1
+            if attempt.wrong_answers >= OIMEFight.ANSWER_LIMIT:
+                attempt.status = "OIME_ALE"
+                attempt.submitted_at = timezone.now()
+                attempt.save()
+                messages.error(
+                    request,
+                    f"Incorrect. You have used all {OIMEFight.ANSWER_LIMIT} attempts.",
+                )
+            else:
+                attempt.save()
+                remaining = OIMEFight.ANSWER_LIMIT - attempt.wrong_answers
+                messages.error(
+                    request,
+                    f"Incorrect. {remaining} attempt{'' if remaining == 1 else 's'} remaining.",
+                )
 
     return redirect("oime-proposal-fight", pk)
 
@@ -817,37 +835,50 @@ def give_up(request: HttpRequest, pk: int) -> HttpResponse:
     if contributor is None:
         return redirect("oime-setup")
 
-    attempt = get_object_or_404(OIMEFight, contributor=contributor, proposal=proposal)
-
-    # A session whose clock already ran out is a time-out, not a give-up: record it
-    # as such so it neither burns a give-up nor logs a bogus multi-hour solve time.
-    if attempt.status == "OIME_TBD" and attempt.time_expired:
-        attempt.status = "OIME_TLE"
-        attempt.submitted_at = timezone.now()
-        attempt.save()
-        messages.warning(request, "The time limit for your timed session has expired.")
-        return redirect("oime-proposal-detail", pk)
-
-    if attempt.status == "OIME_TBD":
-        window_start = timezone.now() - timedelta(minutes=GIVE_UP_WINDOW_MINUTES)
-        recent_give_ups = OIMEFight.objects.filter(
+    # The contributor lock is what makes the give-up rate limit hold: it counts
+    # rows across proposals, so give-ups on two problems at once would otherwise
+    # both read the same count. This is the only view here that takes both locks,
+    # and no other takes the fight before the contributor, so the order can't
+    # cycle.
+    with transaction.atomic():
+        OIMEContributor.objects.select_for_update().get(pk=contributor.pk)
+        attempt = get_object_or_404(
+            OIMEFight.objects.select_for_update(),
             contributor=contributor,
-            status="OIME_FAIL",
-            submitted_at__gte=window_start,
-        ).count()
-        if recent_give_ups >= GIVE_UP_RATE_LIMIT:
-            messages.error(
-                request,
-                f"You have given up {GIVE_UP_RATE_LIMIT} times in the last "
-                f"{GIVE_UP_WINDOW_MINUTES} minutes. Please wait before giving up again.",
-            )
-            return redirect("oime-proposal-fight", pk)
-        attempt.status = "OIME_FAIL"
-        attempt.submitted_at = timezone.now()
-        attempt.save()
-        messages.info(
-            request, "You gave up on this problem. You can now view the solution."
+            proposal=proposal,
         )
+
+        # A session whose clock already ran out is a time-out, not a give-up: record
+        # it as such so it neither burns a give-up nor logs a bogus multi-hour time.
+        if attempt.status == "OIME_TBD" and attempt.time_expired:
+            attempt.status = "OIME_TLE"
+            attempt.submitted_at = timezone.now()
+            attempt.save()
+            messages.warning(
+                request, "The time limit for your timed session has expired."
+            )
+            return redirect("oime-proposal-detail", pk)
+
+        if attempt.status == "OIME_TBD":
+            window_start = timezone.now() - timedelta(minutes=GIVE_UP_WINDOW_MINUTES)
+            recent_give_ups = OIMEFight.objects.filter(
+                contributor=contributor,
+                status="OIME_FAIL",
+                submitted_at__gte=window_start,
+            ).count()
+            if recent_give_ups >= GIVE_UP_RATE_LIMIT:
+                messages.error(
+                    request,
+                    f"You have given up {GIVE_UP_RATE_LIMIT} times in the last "
+                    f"{GIVE_UP_WINDOW_MINUTES} minutes. Please wait before giving up again.",
+                )
+                return redirect("oime-proposal-fight", pk)
+            attempt.status = "OIME_FAIL"
+            attempt.submitted_at = timezone.now()
+            attempt.save()
+            messages.info(
+                request, "You gave up on this problem. You can now view the solution."
+            )
 
     return redirect("oime-proposal-detail", pk)
 
@@ -870,13 +901,17 @@ def reveal_solution(request: HttpRequest, pk: int) -> HttpResponse:
 
     _deny_if_hidden(request, proposal, contributor)
 
-    active_fight = OIMEFight.objects.filter(
-        contributor=contributor, proposal=proposal, status="OIME_TBD"
-    ).exists()
-    if active_fight:
-        raise PermissionDenied
+    # Same contributor lock as start_fight, so that revealing and starting a
+    # fight can't interleave and leave the problem both revealed and being fought.
+    with transaction.atomic():
+        OIMEContributor.objects.select_for_update().get(pk=contributor.pk)
+        active_fight = OIMEFight.objects.filter(
+            contributor=contributor, proposal=proposal, status="OIME_TBD"
+        ).exists()
+        if active_fight:
+            raise PermissionDenied
 
-    contributor.revealed_proposals.add(proposal)
+        contributor.revealed_proposals.add(proposal)
     return redirect("oime-proposal-detail", pk)
 
 


### PR DESCRIPTION
Bug fix. Closes findings [3], [4], [10], and [12] from the security review — the four remaining race conditions.

All four are the same shape: read some state, decide an action is allowed, then write, with nothing holding the state still in between. Parallel requests all pass the same check and all write. Each is fixed the way #541 already fixed the Stripe credit path — one `transaction.atomic()`, holding the row the invariant is actually about. **No schema changes.**

## What changed

**`roster/views.py` — registration [12]**
The `ApplyUUID` is fetched `select_for_update()` and the whole redemption (registration, UUID claim, user name/email, `build_student`) is one transaction. Two accounts sent the same passcode could both find it unused and each end up enrolled and Verified. The transaction also fixes a second problem: a failure partway through (e.g. `Student` hitting its `(user, semester)` unique constraint) used to burn the passcode without producing a student.

**`payments/views.py` — `job_claim` [10]**
Locks the worker and the target job. The `max_pending`/`max_total` quotas count that worker's rows across the folder, so claims on *different* jobs could each see room and all succeed. Locking the worker is what serializes them; locking the job settles two workers racing for the same one.

**`opal/views.py` — guess limit [3]**
A guess locks the puzzle row and rechecks the budget before writing the attempt. Parallel guesses otherwise all read the same remaining count and all get evaluated, overrunning `guess_limit`. The eligibility predicate is extracted to `_can_attempt` so the optimistic check and the authoritative recheck can't drift apart.

One thing worth flagging: the Discord ping on a solve deliberately stays **outside** the lock. `_discord_send_congratulations` is a `requests.post` with no timeout, and holding the puzzle row across it would stall every other guess on that puzzle for as long as Discord took to answer.

**`tubes/views.py` — OIME [4]**
- `start_fight` locks the contributor across the exists-then-create. The unique constraint is `(contributor, proposal)`, so it does nothing to stop starts on two *different* proposals from both opening a session.
- `submit_answer` locks the fight row, which otherwise loses increments to `wrong_answers` and grades more than `ANSWER_LIMIT` answers.
- `give_up` and `reveal_solution` take the same locks. These weren't named in the finding, but they race identically — the give-up rate limit counts rows across proposals, and "revealing forfeits the fight" is a check-then-act against the same contributor state. Fixing the one-active-fight rule and leaving these would have been half a fix.

Lock ordering: `give_up` is the only view taking both, and nothing takes the fight before the contributor, so the order can't cycle.

## On testing — please read

**`select_for_update()` is a silent no-op on SQLite**, which is what the suite runs on. The locking itself is therefore not exercised by any test here, and I don't want that to be invisible in review. The two tests I added cover the guarantees SQLite *can* observe, and I checked both fail without their fix:

- `test_registration_is_all_or_nothing` — a failure mid-redemption leaves the passcode unspent and no partial state.
- `test_guess_budget_is_rechecked_under_the_lock` — a guess whose budget disappeared before the lock was acquired is refused.

Everything else rests on the diffs being small and matching the pattern already in `process_payment`. Existing coverage for the sequential paths (wrong/expired/already-used passcode, guess-limit exhaustion, folder quotas, fights) is unchanged and passing.

`make check` clean, `make fmt` clean, 394 tests passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRS8b9rF1i9eBA7xHWcKH2)_