### PR TITLE
fix: require POST for job claims, inquiry cancels, and Mystery unlocks

### DIFF
--- a/payments/tests.py
+++ b/payments/tests.py
@@ -408,6 +408,20 @@ def test_claim_limits(otis) -> None:
 
 
 @pytest.mark.django_db
+def test_claim_rejects_get(otis) -> None:
+    verified_group = GroupFactory(name="Verified")
+    alice: User = UserFactory.create(username="alice", groups=(verified_group,))
+    otis.login(alice)
+    otis.post_ok("worker-update", data={"notes": "hi"}, follow=True)
+    job = JobFactory.create()
+
+    # a cross-site navigation is a GET, so claiming can't be reachable that way
+    assert otis.get("job-claim", job.pk).status_code == 405
+    job.refresh_from_db()
+    assert job.assignee is None
+
+
+@pytest.mark.django_db
 def test_job_update_permissions(otis) -> None:
     verified_group = GroupFactory(name="Verified")
     alice = WorkerFactory.create(user__username="alice", user__groups=(verified_group,))

--- a/payments/views.py
+++ b/payments/views.py
@@ -24,6 +24,7 @@ from django.http.response import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import UpdateView
 from django.views.generic.list import ListView
@@ -364,6 +365,7 @@ class JobDetail(VerifiedRequiredMixin, DetailView[Job]):
 
 @login_required
 @verified_required
+@require_POST
 def job_claim(request: HttpRequest, pk: int) -> HttpResponse:
     assert isinstance(request.user, User)
     try:

--- a/roster/templates/roster/mystery_unlock.html
+++ b/roster/templates/roster/mystery_unlock.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+{% block title %}
+  Unlock the rest of Mystery
+{% endblock title %}
+{% block layout-content %}
+  <div class="alert alert-warning">
+    This will remove the Mystery unit from your curriculum and replace it with
+    the {% if delta == 1 %}easier{% else %}harder{% endif %} of the units behind
+    it. You can't undo this yourself.
+  </div>
+  <form method="post">
+    {% csrf_token %}
+    <p class="text-center">
+      <input type="submit"
+             class="btn btn-primary"
+             value="Unlock the {% if delta == 1 %}easier{% else %}harder{% endif %} unit" />
+    </p>
+  </form>
+{% endblock layout-content %}

--- a/roster/tests.py
+++ b/roster/tests.py
@@ -317,13 +317,13 @@ def test_mystery(otis) -> None:
     otis.login(alice)
 
     otis.assert_response_denied(
-        otis.client.get("/roster/mystery-unlock/easier/", follow=True)
+        otis.client.post("/roster/mystery-unlock/easier/", follow=True)
     )
 
     alice.curriculum.set([mystery])
     alice.unlocked_units.set([mystery])
 
-    resp = otis.client.get("/roster/mystery-unlock/harder/", follow=True)
+    resp = otis.client.post("/roster/mystery-unlock/harder/", follow=True)
     otis.assert_response_20x(resp)
 
     assert not alice.curriculum.contains(mystery)
@@ -356,11 +356,29 @@ def test_github_issue_447_fix(otis) -> None:
     )
 
     otis.login(alice)
-    resp = otis.client.get("/roster/mystery-unlock/harder/", follow=True)
+    resp = otis.client.post("/roster/mystery-unlock/harder/", follow=True)
     otis.assert_response_20x(resp)
 
     pset.refresh_from_db()
     assert pset.next_unit_to_unlock is None
+
+
+@pytest.mark.django_db
+def test_mystery_unlock_get_only_confirms(otis) -> None:
+    mystery: Unit = UnitFactory(group__name="Mystery")
+    UnitFactory.create_batch(2)  # next two units
+
+    alice: Student = StudentFactory.create()
+    alice.curriculum.set([mystery])
+    alice.unlocked_units.set([mystery])
+    otis.login(alice)
+
+    # a GET is only the confirmation page; nothing about the curriculum moves
+    resp = otis.client.get("/roster/mystery-unlock/harder/")
+    otis.assert_response_20x(resp)
+    assert resp.context["delta"] == 2
+    assert alice.curriculum.contains(mystery)
+    assert alice.unlocked_units.contains(mystery)
 
 
 @pytest.mark.django_db
@@ -1063,6 +1081,24 @@ def test_cancel_inquiry_sets_status_to_canceled(otis) -> None:
     inquiry.refresh_from_db()
     assert inquiry.status == "INQ_CANC"
     otis.assert_message(resp, "Inquiry successfully canceled.")
+
+
+@pytest.mark.django_db
+def test_cancel_inquiry_rejects_get(otis) -> None:
+    alice = StudentFactory.create()
+    unit = UnitFactory.create()
+    inquiry = UnitInquiry.objects.create(
+        student=alice,
+        unit=unit,
+        action_type="INQ_ACT_UNLOCK",
+        status="INQ_NEW",
+        explanation="Please unlock",
+    )
+    otis.login(alice)
+    # a cross-site navigation is a GET, so canceling can't be reachable that way
+    assert otis.get("inquiry-cancel", inquiry.pk).status_code == 405
+    inquiry.refresh_from_db()
+    assert inquiry.status == "INQ_NEW"
 
 
 @pytest.mark.django_db

--- a/roster/views.py
+++ b/roster/views.py
@@ -39,6 +39,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
+from django.views.decorators.http import require_POST
 from django.views.generic.edit import UpdateView
 from django.views.generic.list import ListView
 from django_discordo import SUCCESS_LOG_LEVEL
@@ -418,6 +419,7 @@ def inquiry(request: AuthHttpRequest, student_pk: int) -> HttpResponse:
 
 
 @login_required
+@require_POST
 def cancel_inquiry(request: AuthHttpRequest, pk: int) -> HttpResponse:
     inquiry = get_object_or_404(UnitInquiry, pk=pk)
     if inquiry.student.user != request.user and not request.user.is_staff:
@@ -570,6 +572,13 @@ def unlock_rest_of_mystery(request: HttpRequest, delta: int = 1) -> HttpResponse
         raise PermissionDenied(
             f"You don't have the Mystery unit unlocked!\nYou are currently {student}",
         )
+
+    # Students reach this by typing the URL rather than from a link, so a GET
+    # asks for confirmation instead of acting: Django exempts safe methods from
+    # CSRF checks, and swapping someone's units shouldn't be something another
+    # site can trigger by navigating them here.
+    if request.method != "POST":
+        return render(request, "roster/mystery_unlock.html", {"delta": delta})
 
     # Patch the exploit in https://github.com/vEnhance/otis-web/issues/447
     # If there is a pending Mystery submission, just accept it but don't process


### PR DESCRIPTION
Describe what kind of changes you made here:

Bug fix — closes finding [13] of the static security report (CWE-352, CSRF).

Django's CSRF middleware exempts safe methods, so a view that mutates on `GET` can be triggered by a cross-site top-level navigation carrying the victim's session cookie. Three views mutated before any method check:

| View | Route | Effect on GET |
| --- | --- | --- |
| `payments.views.job_claim` | `job/claim/<pk>/` | assigns a job to the victim |
| `roster.views.cancel_inquiry` | `inquiry/cancel/<pk>/` | cancels the victim's unit petition |
| `roster.views.unlock_rest_of_mystery` | `mystery-unlock/{easier,harder}/` | swaps the victim's Mystery unit |

### `job_claim` and `cancel_inquiry`

Both are already submitted as POST forms by `payments/job_detail.html` and `roster/inquiry.html`, and their existing tests already POST, so they just gain `@require_POST`. It sits below `@login_required` so an anonymous visitor still gets a login redirect rather than a bare 405.

### `unlock_rest_of_mystery`

This one isn't linked from any template — the URL is handed out for students to visit directly, so making it POST-only would break the workflow it exists to serve. Instead a `GET` renders a new confirmation page whose form carries a CSRF token, and only the `POST` performs the swap. The permission check for actually having Mystery unlocked still runs first, so a student without it gets the same error as before rather than a confirmation page that would fail.

The page deliberately doesn't name the unit that's about to be unlocked; the view's `get_object_or_404` for it stays after the method check so that a confirmation page can't be used to peek at what's behind Mystery.

The legacy `mystery_unlock/` (underscore) paths still 302 to the hyphenated ones; a redirected POST becomes a GET, so those now land on the confirmation page, which is the intended destination anyway.

### Tests

- `test_claim_rejects_get` and `test_cancel_inquiry_rejects_get` — assert 405 and that the object is unchanged.
- `test_mystery_unlock_get_only_confirms` — a GET renders the confirmation page and leaves the curriculum alone.
- The two existing Mystery tests now POST.

`make check` is clean (0 pyright errors, no missing migrations) and `roster` + `payments` pass — 60 tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01675RPzfCV5n9HTLU5bkkEQ)_