### PR TITLE
perf(core): add etags to files for caching

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,8 +1,11 @@
 import io
 import json
 from typing import Any
+from unittest import mock
 
 import pytest
+from django.core.files.base import ContentFile
+from django.core.files.storage import storages
 from django.test.utils import override_settings
 from django.urls import reverse
 from pypdf import PdfReader
@@ -14,8 +17,10 @@ from core.factories import (
     UnitFactory,
     UnitGroupFactory,
     UserFactory,
+    mock_pdf,
 )
 from core.models import Semester
+from core.utils import CACHE_MAX_AGE_SECONDS
 from core.watermark import (
     get_corner_text,
     get_watermark_text,
@@ -153,6 +158,99 @@ def test_watermark_all_pages():
         stamp = verify_corner_stamp(text)
         assert stamp is not None
         assert stamp.pk == alice.pk
+
+
+@pytest.mark.django_db
+@override_settings(TESTING_NEEDS_MOCK_MEDIA=True)
+def test_protected_file_etag(otis):
+    alice = StudentFactory.create()
+    unit = UnitFactory.create()
+    alice.unlocked_units.add(unit)
+    otis.login(alice)
+
+    resp = otis.get_20x("view-problems", unit.pk)
+    etag = resp.headers["ETag"]
+    assert etag.startswith('W/"')
+    assert resp.headers["Cache-Control"] == f"private, max-age={CACHE_MAX_AGE_SECONDS}"
+    assert "Cookie" in resp.headers["Vary"]
+
+    with mock.patch(
+        "core.utils.watermark_pdf", side_effect=AssertionError("re-watermarked")
+    ):
+        # browser has cached content and asks if it's fresh:
+        again = otis.get("view-problems", unit.pk, headers={"if-none-match": etag})
+    assert again.status_code == 304  # not modified
+    assert again.content == b""
+    assert again.headers["ETag"] == etag
+    assert again.headers["Cache-Control"] == f"private, max-age={CACHE_MAX_AGE_SECONDS}"
+    assert "Cookie" in again.headers["Vary"]
+
+    stale = otis.get("view-problems", unit.pk, headers={"if-none-match": 'W/"nope"'})
+    assert stale.status_code == 200
+    assert stale.headers["ETag"] == etag
+
+    tex = otis.get_20x("view-tex", unit.pk)
+    tex_again = otis.get(
+        "view-tex", unit.pk, headers={"if-none-match": tex.headers["ETag"]}
+    )
+    assert tex_again.status_code == 304
+
+
+@pytest.mark.django_db
+@override_settings(TESTING_NEEDS_MOCK_MEDIA=True)
+def test_protected_file_etag_is_per_user(otis):
+    alice = StudentFactory.create()
+    bob = StudentFactory.create()
+    unit = UnitFactory.create()
+    alice.unlocked_units.add(unit)
+    bob.unlocked_units.add(unit)
+
+    otis.login(alice)
+    alice_etag = otis.get_20x("view-problems", unit.pk).headers["ETag"]
+
+    otis.login(bob)
+    resp = otis.get("view-problems", unit.pk, headers={"if-none-match": alice_etag})
+    assert resp.status_code == 200
+    assert resp.headers["ETag"] != alice_etag
+
+
+@pytest.mark.django_db
+@override_settings(TESTING_NEEDS_MOCK_MEDIA=True)
+def test_protected_file_etag_invalidation(otis):
+    alice = StudentFactory.create()
+    unit = UnitFactory.create()
+    alice.unlocked_units.add(unit)
+    otis.login(alice)
+    etag = otis.get_20x("view-problems", unit.pk).headers["ETag"]
+
+    path = f"unit-pdf/{unit.problems_pdf_filename}"
+    protected = storages["protected"]
+    protected.delete(path)
+    protected.save(path, ContentFile(mock_pdf(b"Revised")))
+    resp = otis.get("view-problems", unit.pk, headers={"if-none-match": etag})
+    assert resp.status_code == 200
+    assert resp.headers["ETag"] != etag
+    assert "Revised" in PdfReader(io.BytesIO(resp.content)).pages[0].extract_text()
+
+
+@pytest.mark.django_db
+@override_settings(TESTING_NEEDS_MOCK_MEDIA=True)
+@pytest.mark.parametrize("error", [NotImplementedError, OSError])
+def test_protected_file_without_mtime(otis, error: type[Exception]):
+    alice = StudentFactory.create()
+    unit = UnitFactory.create()
+    alice.unlocked_units.add(unit)
+    otis.login(alice)
+
+    def no_mtime(name: str):
+        raise error
+
+    with mock.patch.object(
+        storages["protected"], "get_modified_time", side_effect=no_mtime
+    ):
+        resp = otis.get_20x("view-problems", unit.pk)
+    assert "ETag" not in resp.headers
+    assert "Prob" in PdfReader(io.BytesIO(resp.content)).pages[0].extract_text()
 
 
 @pytest.mark.django_db

--- a/core/utils.py
+++ b/core/utils.py
@@ -2,18 +2,43 @@ import logging
 
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
-from django.core.files.storage import storages
+from django.core.files.storage import Storage, storages
 from django.http import Http404, HttpRequest
 from django.http.response import (
     HttpResponse,
     HttpResponseBadRequest,
     HttpResponseServerError,
 )
+from django.utils.cache import get_conditional_response
+from django.utils.crypto import salted_hmac
 
 from core.models import UserProfile
 from core.watermark import watermark_pdf
 
 logger = logging.getLogger(__name__)
+
+ETAG_SALT = "core.utils.protected_file"
+ETAG_LENGTH = 32
+
+CACHE_MAX_AGE_SECONDS = 15 * 60
+
+
+def get_protected_etag(storage: Storage, path: str, user: User) -> str | None:
+    try:
+        mtime = storage.get_modified_time(path)
+    except Exception:
+        logger.exception("Could not stat %s, serving it unconditionally", path)
+        return None
+    payload = f"{path}:{mtime.timestamp()}:{user.pk}"
+    digest = salted_hmac(ETAG_SALT, payload, algorithm="sha256").hexdigest()
+    return f'W/"{digest[:ETAG_LENGTH]}"'
+
+
+def add_cache_headers(response: HttpResponse, etag: str | None) -> HttpResponse:
+    if etag is not None:
+        response["ETag"] = etag
+    response["Cache-Control"] = f"private, max-age={CACHE_MAX_AGE_SECONDS}"
+    return response
 
 
 def get_protected_file(
@@ -39,22 +64,24 @@ def get_protected_file(
         logger.critical(errmsg)
         return HttpResponseServerError("File not found")
 
-    if ext == ".pdf":
-        with file:
-            content = watermark_pdf(file.read(), request.user)
-    else:
-        content = file
+    with file:
+        etag = get_protected_etag(storage, path, request.user)
+        conditional_response = get_conditional_response(request, etag=etag)
+        if conditional_response is not None:
+            return add_cache_headers(conditional_response, etag)
+        content = file.read()
 
-    response = HttpResponse(content=content)
     if ext == ".pdf":
+        response = HttpResponse(content=watermark_pdf(content, request.user))
         response["Content-Type"] = "application/pdf"
         response["Content-Disposition"] = (
             f'{"inline" if inline_pdf else "attachment"}; filename="{filename}"'
         )
     else:
+        response = HttpResponse(content=content)
         response["Content-Type"] = "text/plain; charset=utf-8"
         response["Content-Disposition"] = (
             f'{"inline" if inline_tex else "attachment"}; filename="{filename}"'
         )
 
-    return response
+    return add_cache_headers(response, etag)


### PR DESCRIPTION
watermarking is expensive for long PDFs, so avoid doing so if client's copy isn't stale, by using an etag (and add cache-control as well, while we're at it i guess). this mildly annoyed me lol

this does mean that the timestamp represents the last time the file was downloaded, not the last time it was accessed, but i think that's fine