### PR TITLE
refactor(opal): fold the eligibility checks into one helper

### DIFF
--- a/opal/tests.py
+++ b/opal/tests.py
@@ -9,6 +9,7 @@ from freezegun.api import freeze_time
 
 from core.factories import GroupFactory, UserFactory
 from opal.factories import OpalAttemptFactory, OpalHuntFactory, OpalPuzzleFactory
+from opal.views import _Eligibility
 from rpg.factories import AchievementFactory
 from rpg.models import AchievementUnlock
 
@@ -712,7 +713,7 @@ def test_close_answer(otis):
 def test_guess_budget_is_rechecked_under_the_lock(otis):
     """A guess that stops being eligible while it waits for the lock is refused.
 
-    The first `_can_attempt` is the optimistic check that decides whether to show
+    The first `_eligibility` is the optimistic check that decides whether to show
     the form; the second runs holding the puzzle row. A guess submitted in
     parallel that used up the last of the budget in between shows up here as the
     two disagreeing, and the later guess must not be evaluated.
@@ -726,7 +727,13 @@ def test_guess_budget_is_rechecked_under_the_lock(otis):
         slug="one", answer="1", hunt=hunt, num_to_unlock=0, guess_limit=3
     )
 
-    with mock.patch("opal.views._can_attempt", side_effect=[True, False]):
+    with mock.patch(
+        "opal.views._eligibility",
+        side_effect=[
+            _Eligibility(False, OpalAttempt.objects.none(), True),
+            _Eligibility(False, OpalAttempt.objects.none(), False),
+        ],
+    ):
         otis.post_40x(
             "opal-show-puzzle", "hunt", "one", data={"guess": "1"}, follow=True
         )

--- a/opal/views.py
+++ b/opal/views.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import Any
+from typing import Any, NamedTuple
 
 import requests
 from allauth.socialaccount.models import SocialAccount
@@ -227,24 +227,29 @@ def _discord_send_congratulations(request: AuthHttpRequest, hunt: OpalHunt):
     requests.post(url=hunt.discord_webhook_url, json={"content": message})
 
 
-def _incorrect_attempts(puzzle: OpalPuzzle, user: User) -> QuerySet[OpalAttempt]:
-    """The attempts by `user` that count against the guess limit on `puzzle`."""
-    return OpalAttempt.objects.filter(
+class _Eligibility(NamedTuple):
+    """Where `user` stands on `puzzle`: solved it, guesses spent, guess left?"""
+
+    is_solved: bool
+    incorrect_attempts: QuerySet[OpalAttempt]
+    can_attempt: bool
+
+
+def _eligibility(puzzle: OpalPuzzle, user: User) -> _Eligibility:
+    is_solved = OpalAttempt.objects.filter(
+        puzzle=puzzle, user=user, is_correct=True
+    ).exists()
+    incorrect_attempts = OpalAttempt.objects.filter(
         puzzle=puzzle,
         user=user,
         excused=False,
         is_close=False,
         is_correct=False,
     ).order_by("-created_at")
-
-
-def _can_attempt(puzzle: OpalPuzzle, user: User) -> bool:
-    """Whether `user` has a guess left on `puzzle` and hasn't already solved it."""
-    is_solved = OpalAttempt.objects.filter(
-        puzzle=puzzle, user=user, is_correct=True
-    ).exists()
-    return (
-        not is_solved and _incorrect_attempts(puzzle, user).count() < puzzle.guess_limit
+    return _Eligibility(
+        is_solved=is_solved,
+        incorrect_attempts=incorrect_attempts,
+        can_attempt=(not is_solved and incorrect_attempts.count() < puzzle.guess_limit),
     )
 
 
@@ -262,26 +267,29 @@ def show_puzzle(
                 "Warning: this puzzle isn't unlocked yet. Showing for testsolvers and admins only.",
             )
 
-    is_solved = OpalAttempt.objects.filter(
-        puzzle=puzzle, user=request.user, is_correct=True
-    ).exists()
-    incorrect_attempts = _incorrect_attempts(puzzle, request.user)
-    can_attempt = _can_attempt(puzzle, request.user)
+    eligibility = _eligibility(puzzle, request.user)
 
     if request.method == "POST":
-        if not can_attempt:
+        if not eligibility.can_attempt:
             raise PermissionDenied("You cannot attempt this puzzle anymore.")
         form = AttemptForm(request.POST)
         if form.is_valid():
             # Hold the puzzle row while the guess budget is rechecked and the
             # attempt is written. Without it, guesses submitted in parallel all
             # read the same remaining count and all get evaluated, so the limit
-            # can be overrun. Keep this block short and free of network calls:
-            # everything else on this puzzle waits behind the lock until it
-            # commits, so the Discord ping below stays outside it.
+            # can be overrun.
+            #
+            # The lock has to be on the puzzle and not on the attempts: the race
+            # is over a row that doesn't exist yet, and Django talks to MySQL at
+            # READ COMMITTED, where InnoDB takes no gap locks. Locking the
+            # existing attempts would not stop the new INSERT.
+            #
+            # Keep this block short and free of network calls: every other guess
+            # on this puzzle waits behind the lock until it commits, which is why
+            # the Discord ping below stays outside it.
             with transaction.atomic():
                 puzzle = OpalPuzzle.objects.select_for_update().get(pk=puzzle.pk)
-                if not _can_attempt(puzzle, request.user):
+                if not _eligibility(puzzle, request.user).can_attempt:
                     raise PermissionDenied("You cannot attempt this puzzle anymore.")
                 attempt = OpalAttempt(
                     guess=form.cleaned_data["guess"],
@@ -312,7 +320,7 @@ def show_puzzle(
                 messages.warning(request, f"Sorry, wrong answer to {puzzle.title}.")
             return HttpResponseRedirect(puzzle.get_absolute_url())
 
-    elif can_attempt is True:
+    elif eligibility.can_attempt is True:
         form = AttemptForm()
     else:
         form = None
@@ -324,15 +332,15 @@ def show_puzzle(
     context: dict[str, Any] = {}
     context["puzzle"] = puzzle
     context["hunt"] = puzzle.hunt
-    context["solved"] = is_solved
+    context["solved"] = eligibility.is_solved
     context["attempts"] = attempts
     context["form"] = form
-    context["can_attempt"] = can_attempt
+    context["can_attempt"] = eligibility.can_attempt
     context["show_hints"] = (
         timezone.now() >= puzzle.hunt.hints_released_date
         or has_early_access(request.user)
     )
-    context["incorrect_attempts"] = incorrect_attempts
+    context["incorrect_attempts"] = eligibility.incorrect_attempts
     return render(request, "opal/showpuzzle.html", context)
 
 


### PR DESCRIPTION
Follow-up to #544, which is already merged. Cleanup only — no behavior change.

## The problem

#544 extracted `_can_attempt` so the optimistic check and the authoritative recheck under the lock couldn't drift apart, but left the original inline computation sitting next to it. The result was that `is_solved` ran **twice per request**: once for the template context, and again inside `_can_attempt`.

The locals survived because the template needs `solved` and `incorrect_attempts` separately from `can_attempt`.

## The fix

Return the three related facts from a single call:

```python
class _Eligibility(NamedTuple):
    """Where `user` stands on `puzzle`: solved it, guesses spent, guess left?"""
    is_solved: bool
    incorrect_attempts: QuerySet[OpalAttempt]
    can_attempt: bool
```

The view becomes `eligibility = _eligibility(puzzle, request.user)`; the recheck under the lock is `_eligibility(puzzle, request.user).can_attempt`. The predicate is written once, and the duplicate `exists()` is gone.

I measured the query count rather than assuming it, instrumenting the view with `CaptureQueriesContext` and comparing against the pre-#544 code:

```
ORIGINAL (pre-fix): OpalAttempt queries on GET: 5
NOW:                OpalAttempt queries on GET: 5
```

Exact parity — the extra query #544 introduced is paid back.

## Also

Added a comment at the lock site recording *why* the lock is on `OpalPuzzle` rather than on the attempts, since it's a reasonable thing to wonder on the next read. The race is over a row that doesn't exist yet, and Django's MySQL backend defaults to `read committed` (`django/db/backends/mysql/base.py:240`, not overridden in `otisweb/settings.py`), where InnoDB takes no gap locks — so locking the existing attempt rows would not have blocked the new `INSERT`. It would have looked correct and silently failed in production.

`test_guess_budget_is_rechecked_under_the_lock` now patches `_eligibility`; I re-confirmed it still fails when the recheck is deleted, so it isn't passing vacuously.

`make check` clean, `make fmt` clean, 401 tests passing on current main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRS8b9rF1i9eBA7xHWcKH2)_