### PR TITLE
fix(roster): catch double-submitted petitions better

### DIFF
--- a/roster/tests.py
+++ b/roster/tests.py
@@ -1033,6 +1033,73 @@ def test_inquiry_cant_rapid_fire(otis) -> None:
 
 
 @pytest.mark.django_db
+def test_inquiry_cant_rapid_fire_after_auto_reject(otis) -> None:
+    """A double submit is caught even when the first copy was auto-rejected."""
+    with freeze_time("2025-10-31", tz_offset=0):
+        alice: Student = StudentFactory.create()
+        unit: Unit = UnitFactory.create()
+        alice.curriculum.add(unit)
+        alice.unlocked_units.add(unit)
+        PSetFactory.create(student=alice, unit=unit, status="P")
+        otis.login(alice)
+
+        data = {
+            "unit": unit.pk,
+            "action_type": "INQ_ACT_DROP",
+            "explanation": "drop this unit please",
+        }
+        otis.assert_message(
+            otis.post("inquiry", alice.pk, data=data, follow=True),
+            "You have a pending submission for this unit.",
+        )
+        otis.assert_message(
+            otis.post("inquiry", alice.pk, data=data, follow=True),
+            "The same petition already was submitted within the last 90 seconds.",
+        )
+        assert (
+            UnitInquiry.objects.filter(
+                student=alice, unit=unit, action_type="INQ_ACT_DROP"
+            ).count()
+            == 1
+        )
+
+
+@pytest.mark.django_db
+def test_inquiry_can_resubmit_after_cancel(otis) -> None:
+    """Canceling a petition lets the student submit the same one right away."""
+    with freeze_time("2025-10-31", tz_offset=0):
+        alice: Student = StudentFactory.create()
+        unit: Unit = UnitFactory.create()
+        inquiry = UnitInquiry.objects.create(
+            student=alice,
+            unit=unit,
+            action_type="INQ_ACT_UNLOCK",
+            explanation="changed my mind",
+            status="INQ_CANC",
+        )
+        otis.login(alice)
+        otis.assert_message(
+            otis.post(
+                "inquiry",
+                alice.pk,
+                data={
+                    "unit": unit.pk,
+                    "action_type": "INQ_ACT_UNLOCK",
+                    "explanation": "actually i do want this one",
+                },
+                follow=True,
+            ),
+            "Petition automatically processed.",
+        )
+        assert (
+            UnitInquiry.objects.filter(student=alice, unit=unit)
+            .exclude(pk=inquiry.pk)
+            .count()
+            == 1
+        )
+
+
+@pytest.mark.django_db
 def test_inquiry_rejects_drop_lock_if_pending_pset(otis) -> None:
     """Drop/lock petition auto-rejected if there's a pending submission."""
     alice: Student = StudentFactory.create()

--- a/roster/views.py
+++ b/roster/views.py
@@ -277,13 +277,20 @@ class UpdateInvoice(
 def handle_inquiry(request: AuthHttpRequest, inquiry: UnitInquiry, student: Student):
     current_inquiries = UnitInquiry.objects.filter(student=student)
     inquiry.student = student
-    # check if exists already and created recently
-    if current_inquiries.filter(
-        unit=inquiry.unit,
-        action_type=inquiry.action_type,
-        created_at__gte=timezone.now() - datetime.timedelta(seconds=90),
-        status__in=("INQ_NEW", "INQ_ACC"),
-    ).exists():
+    # check if exists already and created recently.
+    # every status counts here except INQ_CANC: canceling a petition is the one
+    # action that should let a student immediately submit the same one again.
+    # in particular a double submit whose first copy was auto-rejected or put
+    # on hold still needs to be caught.
+    if (
+        current_inquiries.filter(
+            unit=inquiry.unit,
+            action_type=inquiry.action_type,
+            created_at__gte=timezone.now() - datetime.timedelta(seconds=90),
+        )
+        .exclude(status="INQ_CANC")
+        .exists()
+    ):
         messages.warning(
             request,
             "The same petition already was submitted within the last 90 seconds.",


### PR DESCRIPTION
Bug fix.

The 90-second dedupe check in `handle_inquiry` only looked at petitions with status `INQ_NEW` or `INQ_ACC`:

```python
status__in=("INQ_NEW", "INQ_ACC"),
```

But `handle_inquiry` frequently leaves a petition at `INQ_REJ` (the three auto-reject checks) or `INQ_HOLD` (the abnormal-volume check). When the first copy of a double submit landed in either state, the second submission went straight past the guard and created a second row — deterministically, not as a race, and worst for exactly the students who petition the most.

This inverts the filter: every status counts except `INQ_CANC`, since canceling is the one action that should let a student resubmit the same petition immediately.

Written as an `.exclude()` rather than a longer `status__in` because "canceling is the one thing that lets you resubmit" is the actual rule, and it won't rot if a status is added later.

### Tests

- `test_inquiry_cant_rapid_fire_after_auto_reject` — the drop-with-pending-pset path auto-rejects, and a repeat within 90 seconds must not create a second row. Verified this fails without the `views.py` change.
- `test_inquiry_can_resubmit_after_cancel` — regression guard that cancel-then-resubmit still works.

Full suite passes (403 tests), pyright clean.

### Note

This does not close the underlying race — two POSTs can still both pass the `SELECT` before either commits. That needs a DB-level uniqueness constraint, which needs a migration, so it is deliberately out of scope here. Worth knowing that a conditional `UniqueConstraint` would not help on production: MySQL has `supports_partial_indexes = False`, so Django silently skips it while SQLite tests would still pass.

The browser-side half of this (stopping the second click before it becomes a request) is split out into a separate PR, since it applies to every form on the site rather than just petitions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX8A2PL9CbSkw4WBaC1GJC)_