### PR TITLE
feat(otisweb): guard every POST form against double submission

### DIFF
--- a/otisweb/static/single-submit.js
+++ b/otisweb/static/single-submit.js
@@ -1,0 +1,75 @@
+// Prevent a form from being submitted twice.
+//
+// A slow response invites an impatient second click, and for anything that
+// creates a row or grants something rather than just updating a field, that
+// second click means a duplicate: two unit petitions, two job claims, two
+// mystery unlocks. Every POST on this site is a "do this once" action, so
+// guard them all: the first submit wins, later ones are dropped, and the
+// button shows a spinner so a slow response no longer looks like nothing
+// happened.
+//
+// A form that genuinely wants to be submitted repeatedly can opt out with
+// data-multi-submit. GET forms (searches, lookups) are safe to repeat and are
+// left alone.
+//
+// This is progressive enhancement: with JavaScript off, nothing here runs and
+// every form posts exactly as it did before. Deliberately no jQuery and no
+// DOMContentLoaded wrapper, since both listeners attach to objects that
+// already exist -- the guard is armed before the first form is parsed, and it
+// survives the jQuery CDN being blocked.
+
+(function () {
+  function submitButtons(form) {
+    return form.querySelectorAll("button[type=submit], input[type=submit]");
+  }
+
+  document.addEventListener("submit", function (event) {
+    // another handler already cancelled this submit, so there is nothing to
+    // guard and locking the form would strand it. This is also why the
+    // listener bubbles rather than captures: handlers on the form itself get
+    // to run first.
+    if (event.defaultPrevented) return;
+
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement)) return;
+    if (form.method.toLowerCase() !== "post") return;
+    if (form.hasAttribute("data-multi-submit")) return;
+
+    if (form.dataset.submitting === "1") {
+      event.preventDefault();
+      return;
+    }
+    form.dataset.submitting = "1";
+
+    // disable on the next tick, so the button still contributes its
+    // name/value (if any) to the submitted form data
+    window.setTimeout(function () {
+      submitButtons(form).forEach(function (button) {
+        button.disabled = true;
+        if (button.tagName !== "BUTTON") return;
+        if (button.dataset.originalHtml === undefined) {
+          button.dataset.originalHtml = button.innerHTML;
+        }
+        button.innerHTML =
+          '<span class="spinner-border spinner-border-sm" aria-hidden="true"></span> ' +
+          button.dataset.originalHtml;
+      });
+    }, 0);
+  });
+
+  // the back button can restore the page from the bfcache with the button
+  // still disabled, which would leave the form unusable
+  window.addEventListener("pageshow", function (event) {
+    if (!event.persisted) return;
+    document.querySelectorAll("form").forEach(function (form) {
+      if (form.dataset.submitting !== "1") return;
+      delete form.dataset.submitting;
+      submitButtons(form).forEach(function (button) {
+        button.disabled = false;
+        if (button.dataset.originalHtml !== undefined) {
+          button.innerHTML = button.dataset.originalHtml;
+        }
+      });
+    });
+  });
+})();

--- a/otisweb/templates/base.html
+++ b/otisweb/templates/base.html
@@ -28,6 +28,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
     <script src="{% static "k.js" %}"></script>
     <script src="{% static "number-wheel.js" %}"></script>
+    <script src="{% static "single-submit.js" %}"></script>
     {% if request.user|getconfig:"use_twemoji" %}
       <script src="https://unpkg.com/twemoji@latest/dist/twemoji.min.js"
               crossorigin="anonymous"></script>


### PR DESCRIPTION
Enhancement.

A slow response invites an impatient second click, and for anything that creates a row or grants something rather than just updating a field, that second click means a duplicate. Unit petitions are where this was noticed, but the sharpest cases are elsewhere — job claims, mystery unlocks, finalizing a semester, starting a fight — and those are hand-rolled single-button forms, not built from the `generic_form` component. There are 35 component-built forms and 33 POST forms outside it across 27 templates, so opting in form by form would have missed the ones that matter most.

Every POST on this site is a "do this once" action, so this guards them all. New `otisweb/static/single-submit.js`, loaded in `base.html`. The first submit wins, later ones are dropped, and the button grows a Bootstrap spinner so a slow response no longer looks like nothing happened.

Opt out with `data-multi-submit` on any form that genuinely wants repeat submission. GET forms (the ARCH and unit searches) are safe to repeat and are left alone.

### Design notes

- **Progressive enhancement.** With JavaScript off, nothing runs and every form posts exactly as before. Nothing about submission depends on the script.
- **No jQuery, no `DOMContentLoaded`.** Both listeners attach to `document` and `window`, which exist while `<head>` is still parsing, so the guard is armed before the first form is parsed. It also survives the jQuery CDN being blocked, which would otherwise fail silently and unpredictably — a worse mode than JS simply being off.
- **The submit listener bubbles rather than captures**, and bails on `event.defaultPrevented`. A handler on the form itself gets to run first, so a submit that something else cancels never strands the form in a permanently locked state. Failing open (no guard) is the right direction for this.
- **Buttons are disabled on the next tick**, so they still contribute their name/value to the submitted form data.
- **`pageshow` re-enables** any locked form when the back button restores the page from the bfcache; otherwise a returning user finds a dead form.
- **Django admin is unaffected** — its templates extend `admin/base_site.html`, not this base template. Admin's multi-button save bar and inline formsets are untouched.

Two files: the new script and one `<script>` tag. Full suite passes (401 tests), though this is browser behavior and isn't covered by the Django tests.