### PR TITLE
fix(opal): keep guess log timestamps on one line

### DIFF
--- a/opal/templates/opal/components/attempt_table.html
+++ b/opal/templates/opal/components/attempt_table.html
@@ -22,7 +22,7 @@
       <td class="{% if attempt.is_correct %}text-success{% elif attempt.is_close %}text-dark{% else %}text-danger{% endif %}">
         <tt>{{ attempt.guess|truncatechars:24 }}</tt>
       </td>
-      <td>
+      <td class="text-nowrap">
         {% if attempt.is_correct %}
           ✅
         {% elif attempt.is_close %}

--- a/opal/templates/opal/opalattempt_list.html
+++ b/opal/templates/opal/opalattempt_list.html
@@ -37,7 +37,7 @@
         <td class="{% if attempt.is_correct %}text-success{% elif attempt.is_close %}text-dark{% else %}text-danger{% endif %}">
           <tt>{{ attempt.guess|truncatechars:24 }}</tt>
         </td>
-        <td>
+        <td class="text-nowrap">
           {% if attempt.is_correct %}
             ✅
           {% elif attempt.is_close %}

--- a/opal/templates/opal/person_log.html
+++ b/opal/templates/opal/person_log.html
@@ -41,7 +41,7 @@
         <td>
           <a href="{% url "opal-attempts-list" hunt.slug attempt.puzzle.slug %}">{{ attempt.puzzle.title }}</a>
         </td>
-        <td>
+        <td class="text-nowrap">
           {% if attempt.is_correct %}
             ✅
           {% elif attempt.is_close %}


### PR DESCRIPTION
Bug fix (small CSS-only change).

The timestamp column in the OPAL guess logs wraps between the date and the
time once the other columns claim enough width, so a row renders two lines
tall and the table loses its vertical rhythm. Reported from prod on the hunt
log.

`class="text-nowrap"` on the timestamp cell in the three templates that
render it:

- `opal/templates/opal/components/attempt_table.html` — the shared table
  behind the recent-activity and per-hunt log views
- `opal/templates/opal/opalattempt_list.html` — the per-puzzle answer log
- `opal/templates/opal/person_log.html` — the per-person activity log

The third was not in the reported screenshot, but it renders the same
timestamp cell and wraps the same way, so it is fixed here rather than left
inconsistent with the other two.

No template logic or view code changed, so the existing tests cover this
unchanged; `make fmt`, `make check` and the opal suite are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016WStV14GfczKudQ9iMPdpe)_