### PR TITLE
feat(opal): yellow tint when solver isn't finished

### DIFF
--- a/opal/tests.py
+++ b/opal/tests.py
@@ -843,7 +843,10 @@ def test_guess_log_row_styling(otis):
     with freeze_time("2024-08-15"):
         alice_feeder = OpalAttemptFactory.create(user=alice, puzzle=feeder, guess="one")
         alice_meta = OpalAttemptFactory.create(user=alice, puzzle=meta, guess="two")
-        bob_wrong = OpalAttemptFactory.create(user=bob, puzzle=feeder, guess="nope")
+        # Bob misses the feeder, then gets it, then never does get the meta
+        bob_miss = OpalAttemptFactory.create(user=bob, puzzle=feeder, guess="nope")
+        bob_feeder = OpalAttemptFactory.create(user=bob, puzzle=feeder, guess="one")
+        bob_stuck = OpalAttemptFactory.create(user=bob, puzzle=meta, guess="nope")
 
     expected = {
         # a testsolver's check is grayed out, and their meta is 🆗
@@ -852,8 +855,11 @@ def test_guess_log_row_styling(otis):
         # someone who finished the hunt for real gets ✅, 🈴, and a green row
         alice_feeder.pk: ("✅", "table-success"),
         alice_meta.pk: ("🈴", "table-success"),
-        # a wrong guess from someone still hunting is untinted
-        bob_wrong.pk: ("✖️", ""),
+        # Bob is still hunting: the puzzle he did eventually get is untinted,
+        # a miss on it included, but the one he never got goes yellow
+        bob_miss.pk: ("✖️", ""),
+        bob_feeder.pk: ("✅", ""),
+        bob_stuck.pk: ("✖️", "table-warning"),
     }
 
     def styling(attempts) -> dict[int, tuple[str, str]]:
@@ -872,7 +878,7 @@ def test_guess_log_row_styling(otis):
     # the per-puzzle log sees one puzzle's guesses
     resp = otis.get_20x("opal-attempts-list", "hunt", "meta")
     assert styling(resp.context["attempts"]) == {
-        pk: expected[pk] for pk in (tess_meta.pk, alice_meta.pk)
+        pk: expected[pk] for pk in (tess_meta.pk, alice_meta.pk, bob_stuck.pk)
     }
 
     # the per-user log sees one person's guesses, and a testsolver's stay blue
@@ -881,7 +887,16 @@ def test_guess_log_row_styling(otis):
         pk: expected[pk] for pk in (tess_feeder.pk, tess_meta.pk)
     }
     resp = otis.get_20x("opal-person-log", "hunt", bob.pk)
-    assert styling(resp.context["attempts"]) == {bob_wrong.pk: expected[bob_wrong.pk]}
+    assert styling(resp.context["attempts"]) == {
+        pk: expected[pk] for pk in (bob_miss.pk, bob_feeder.pk, bob_stuck.pk)
+    }
+
+    # once Bob finishes, the hunt-wide green wins over the per-puzzle yellow
+    OpalAttemptFactory.create(user=bob, puzzle=meta, guess="two")
+    resp = otis.get_20x("opal-person-log", "hunt", bob.pk)
+    assert {a.pk: a.row_class for a in resp.context["attempts"]} == {
+        a.pk: "table-success" for a in resp.context["attempts"]
+    }
 
     # and the leaderboard the logs are mirroring agrees on both counts
     resp = otis.get_20x("opal-leaderboard", "hunt")

--- a/opal/views.py
+++ b/opal/views.py
@@ -49,9 +49,11 @@ ATTEMPT_LOG_ORDERING = ("-created_at", "-pk")
 
 
 # How a guesser's standing in a hunt tints their row, on the leaderboard and in
-# every guess log: blue for a testsolver, green for someone who has finished.
+# every guess log: blue for a testsolver, green for someone who has finished,
+# yellow for a guess on a puzzle its guesser never did get.
 TESTSOLVER_ROW_CLASS = "table-primary"
 FINISHER_ROW_CLASS = "table-success"
+UNSOLVED_ROW_CLASS = "table-warning"
 
 
 def correct_emoji(is_testsolver: bool, is_metapuzzle: bool) -> str:
@@ -67,12 +69,22 @@ def correct_emoji(is_testsolver: bool, is_metapuzzle: bool) -> str:
         return "☑️" if is_testsolver else "✅"
 
 
-def standing_row_class(is_testsolver: bool, has_finished: bool) -> str:
-    """The Bootstrap tint for a row belonging to a guesser with this standing."""
+def standing_row_class(
+    is_testsolver: bool, has_finished: bool, puzzle_unsolved: bool = False
+) -> str:
+    """The Bootstrap tint for a row belonging to a guesser with this standing.
+
+    `puzzle_unsolved` says this row is a guess on a puzzle its guesser has no
+    correct answer for anywhere in the hunt, so the guess led nowhere. It only
+    means something for a row about one puzzle: the leaderboard's rows span the
+    whole hunt, so it leaves the argument alone.
+    """
     if is_testsolver:
         return TESTSOLVER_ROW_CLASS
     elif has_finished:
         return FINISHER_ROW_CLASS
+    elif puzzle_unsolved:
+        return UNSOLVED_ROW_CLASS
     else:
         return ""
 
@@ -82,14 +94,23 @@ class _Standing(NamedTuple):
 
     A testsolver is someone who solved something before the hunt opened, the
     same test the leaderboard uses, so the two pages agree on who is who.
+
+    `solved_puzzles` is kept whole rather than counted, since a row also wants
+    to know whether its own puzzle is in there.
     """
 
-    solve_count: int
+    solved_puzzles: frozenset[int]
     is_testsolver: bool
     has_finished: bool
 
+    @property
+    def solve_count(self) -> int:
+        return len(self.solved_puzzles)
 
-NO_SOLVES = _Standing(solve_count=0, is_testsolver=False, has_finished=False)
+
+NO_SOLVES = _Standing(
+    solved_puzzles=frozenset(), is_testsolver=False, has_finished=False
+)
 
 
 def _standings(hunt: OpalHunt, user_pks: Collection[int]) -> dict[int, _Standing]:
@@ -111,7 +132,7 @@ def _standings(hunt: OpalHunt, user_pks: Collection[int]) -> dict[int, _Standing
             finishers.add(user_pk)
     return {
         user_pk: _Standing(
-            solve_count=len(puzzle_pks),
+            solved_puzzles=frozenset(puzzle_pks),
             is_testsolver=user_pk in testsolvers,
             has_finished=user_pk in finishers,
         )
@@ -132,7 +153,8 @@ def decorate_attempts(
       now, which is what makes a row readable: it says how far along the person
       making the guess is.
     * `emoji` and `text_class`, how the guess itself was judged.
-    * `row_class`, the tint for the guesser's standing in the hunt.
+    * `row_class`, the tint for where the guesser stands in the hunt, and for
+      whether they ever solved the puzzle this row is a guess on.
 
     The standings take a single query for the whole page, since
     `OpalHunt.num_solves` would be one query per row. Pass a queryset that has
@@ -147,6 +169,7 @@ def decorate_attempts(
         attempt.row_class = standing_row_class(  # type: ignore[attr-defined]
             is_testsolver=standing.is_testsolver,
             has_finished=standing.has_finished,
+            puzzle_unsolved=attempt.puzzle.pk not in standing.solved_puzzles,
         )
         if attempt.is_correct:
             attempt.emoji = correct_emoji(  # type: ignore[attr-defined]


### PR DESCRIPTION
Enhancement, following up on #562.

## What this changes

A wrong guess reads the same in the log whether the guesser went on to get the puzzle a minute later or never got it at all — and the second case is the more interesting one, since it's where someone was stuck.

This adds a yellow tint (`table-warning`) to any guess-log row whose guesser:

- is not a testsolver, **and**
- has not finished the hunt, **and**
- has no correct answer for that row's puzzle anywhere in the hunt.

The tints from #562 still take precedence, so a testsolver stays blue and someone who finished stays green throughout their rows. Precedence is testsolver → finisher → unsolved → plain.

A correct guess can never be yellow, since its own puzzle is by definition solved. Yellow lands only on wrong and close guesses that led nowhere.

## Query cost

No extra queries. `_standings` was already reading every correct `(user, puzzle)` pair for the page and then discarding the puzzle identity by collapsing to a count, so `_Standing` now keeps the set and derives `solve_count` off it:

```python
solved_puzzles: frozenset[int]

@property
def solve_count(self) -> int:
    return len(self.solved_puzzles)
```

Measured at 2, 50, and 100 rows, the four logs stay at the same counts as before this change — 10 (hunt log), 9 (recent activity), 12 (per-puzzle), 12 (per-user) — which is what `test_guess_log_query_count` pins.

## Note on the shared helper

`standing_row_class` gained `puzzle_unsolved: bool = False`. It's defaulted because the leaderboard calls the same helper, and its rows span the whole hunt rather than one puzzle, so there is no "this puzzle" to ask about there. Leaderboard rows are unaffected.

## Testing

`test_guess_log_row_styling` now has Bob miss the feeder, get it, then get stuck on the meta forever — pinning that the miss-then-solved row stays plain while the never-solved row goes yellow — plus a check that once Bob finishes the hunt, all of his rows flip green.

Full suite passes (423), `make check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8LhUSTfyDZw4i7RpU1PZp)_