### PR TITLE
feat(tubes): casual browser header polish and voting from the card

### DIFF
--- a/otisweb/static/css/otis.css
+++ b/otisweb/static/css/otis.css
@@ -404,14 +404,6 @@ img.emoji {
 .oime-upvote-btn:active {
   transform: scale(0.95);
 }
-.oime-upvote-btn:disabled {
-  cursor: default;
-  opacity: 0.65;
-}
-.oime-upvote-btn:disabled:hover {
-  transform: none;
-  box-shadow: none;
-}
 
 /* OIME proposal table collapse toggle */
 .oime-table-toggle::before {

--- a/otisweb/static/css/otis.css
+++ b/otisweb/static/css/otis.css
@@ -404,6 +404,14 @@ img.emoji {
 .oime-upvote-btn:active {
   transform: scale(0.95);
 }
+.oime-upvote-btn:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+.oime-upvote-btn:disabled:hover {
+  transform: none;
+  box-shadow: none;
+}
 
 /* OIME proposal table collapse toggle */
 .oime-table-toggle::before {

--- a/tubes/templates/tubes/casual_browse.html
+++ b/tubes/templates/tubes/casual_browse.html
@@ -24,9 +24,20 @@
              data-testid="browse-difficulty-badge"
              title="{% if difficulty %}Clear the difficulty filter{% else %}Show only 🔥 × {{ proposal.difficulty }} problems{% endif %}"
              href="{% url "oime-casual-browse" subject %}{% if proposal.difficulty_params %}?{{ proposal.difficulty_params }}{% endif %}">{{ proposal.difficulty_display }}</a>
-          <span class="badge border {% if proposal.has_upvoted %}bg-danger text-white{% else %}bg-light text-dark{% endif %}"
-                {% if proposal.has_upvoted %}data-testid="browse-upvoted"{% endif %}
-                title="{% if proposal.has_upvoted %}You upvoted this problem{% else %}You have not upvoted this problem{% endif %}">🩷 × {{ proposal.upvote_count }}</span>
+          <form method="post"
+                action="{% url "oime-upvote" proposal.pk %}"
+                class="d-inline">
+            {% csrf_token %}
+            <input type="hidden" name="back_subject" value="{{ subject }}" />
+            <input type="hidden" name="back_params" value="{{ back_params }}" />
+            <button type="submit"
+                    class="badge border oime-upvote-btn {% if proposal.has_upvoted %}bg-danger text-white{% else %}bg-light text-dark{% endif %}"
+                    {% if proposal.has_upvoted %}data-testid="browse-upvoted"{% endif %}
+                    {% if not proposal.can_upvote %}disabled{% endif %}
+                    title="{% if not proposal.can_upvote %}Finish your attempt before voting on this problem{% elif proposal.has_upvoted %}Click to remove your upvote{% else %}Click to upvote this problem{% endif %}">
+              🩷 × {{ proposal.upvote_count }}
+            </button>
+          </form>
         </span>
       </div>
       <div class="card-body">

--- a/tubes/templates/tubes/casual_browse.html
+++ b/tubes/templates/tubes/casual_browse.html
@@ -15,15 +15,18 @@
   </p>
   {% for proposal in page_obj %}
     <div class="card mb-4 {% if proposal.spoiled %}border-secondary{% else %}border-primary{% endif %}">
-      <div class="card-header d-flex justify-content-between align-items-start gap-2">
+      <div class="card-header d-flex justify-content-between align-items-center gap-2">
         <span class="fw-bold">
           <a href="{{ proposal.get_absolute_url }}">{{ proposal.label }}: {{ proposal.title|truncatechars:"32" }}</a>
         </span>
-        <span class="d-flex gap-2 text-nowrap">
-          <span class="badge border px-2 py-2 {% if proposal.has_upvoted %}bg-danger text-white{% else %}bg-light text-dark{% endif %}"
+        <span class="d-flex align-items-center gap-1 text-nowrap">
+          <a class="badge border text-decoration-none {% if difficulty %}bg-primary text-white{% else %}bg-light text-dark{% endif %}"
+             data-testid="browse-difficulty-badge"
+             title="{% if difficulty %}Clear the difficulty filter{% else %}Show only 🔥 × {{ proposal.difficulty }} problems{% endif %}"
+             href="{% url "oime-casual-browse" subject %}{% if proposal.difficulty_params %}?{{ proposal.difficulty_params }}{% endif %}">{{ proposal.difficulty_display }}</a>
+          <span class="badge border {% if proposal.has_upvoted %}bg-danger text-white{% else %}bg-light text-dark{% endif %}"
                 {% if proposal.has_upvoted %}data-testid="browse-upvoted"{% endif %}
                 title="{% if proposal.has_upvoted %}You upvoted this problem{% else %}You have not upvoted this problem{% endif %}">🩷 × {{ proposal.upvote_count }}</span>
-          <span class="badge bg-light text-dark border px-2 py-2">{{ proposal.difficulty_display }}</span>
         </span>
       </div>
       <div class="card-body">

--- a/tubes/templates/tubes/casual_browse.html
+++ b/tubes/templates/tubes/casual_browse.html
@@ -33,8 +33,7 @@
             <button type="submit"
                     class="badge border oime-upvote-btn {% if proposal.has_upvoted %}bg-danger text-white{% else %}bg-light text-dark{% endif %}"
                     {% if proposal.has_upvoted %}data-testid="browse-upvoted"{% endif %}
-                    {% if not proposal.can_upvote %}disabled{% endif %}
-                    title="{% if not proposal.can_upvote %}Finish your attempt before voting on this problem{% elif proposal.has_upvoted %}Click to remove your upvote{% else %}Click to upvote this problem{% endif %}">
+                    title="{% if proposal.has_upvoted %}Click to remove your upvote{% else %}Click to upvote this problem{% endif %}">
               🩷 × {{ proposal.upvote_count }}
             </button>
           </form>

--- a/tubes/templates/tubes/landing.html
+++ b/tubes/templates/tubes/landing.html
@@ -84,8 +84,9 @@
   </p>
   <p>
     After you solve or give up on a proposal, you can read spoilers and comment
-    on the thread for the problem. You can also upvote the problem using the heart
-    icon to indicate that you like it.
+    on the thread for the problem. Once you have seen a problem's statement, you
+    can upvote it using the heart icon to indicate that you like it; you do not
+    have to wait until you have finished with it.
   </p>
   <h2>How Evan picks the 15 problems</h2>
   <p>For now, final selection of problems and placements is done by Evan.</p>

--- a/tubes/tests.py
+++ b/tubes/tests.py
@@ -1092,30 +1092,6 @@ def test_casual_browse_difficulty_badges_toggle_the_filter(otis):
 
 
 @pytest.mark.django_db
-def test_casual_browse_blocks_voting_during_a_ranked_fight(otis):
-    user, contributor = _verified_contributor()
-    contributor.casual_mode = True
-    contributor.save()
-    # A fight still running keeps the solution hidden, and the vote with it.
-    running = OIMEProposalFactory.create(subject="C")
-    OIMEFightFactory.create(
-        contributor=contributor, proposal=running, status="OIME_TBD"
-    )
-    finished = OIMEProposalFactory.create(subject="C")
-    OIMEFightFactory.create(
-        contributor=contributor, proposal=finished, status="OIME_OK"
-    )
-    untouched = OIMEProposalFactory.create(subject="C")
-    otis.login(user)
-    resp = otis.get_20x("oime-casual-browse", "C")
-    assert {p.pk: p.can_upvote for p in resp.context["page_obj"]} == {
-        running.pk: False,
-        finished.pk: True,
-        untouched.pk: True,
-    }
-
-
-@pytest.mark.django_db
 def test_casual_browse_marks_upvoted_problems(otis):
     user, contributor = _verified_contributor()
     contributor.casual_mode = True
@@ -1453,6 +1429,40 @@ def test_upvote_return_ignores_bogus_browse_params(otis):
     )
     otis.assert_30x(resp)
     assert resp.url == "/tubes/casual/G/"
+
+
+@pytest.mark.django_db
+def test_upvote_allowed_during_a_running_fight(otis):
+    # Voting needs the statement, not the solution, so a clock still running is no
+    # reason to withhold the heart from someone already reading the problem. The
+    # casual browser is where this is reachable: the detail view sends a ranked
+    # contributor mid-fight to the fight page instead.
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    proposal = OIMEProposalFactory.create(subject="C")
+    OIMEFightFactory.create(
+        contributor=contributor, proposal=proposal, status="OIME_TBD"
+    )
+    otis.login(user)
+    resp = otis.post("oime-upvote", proposal.pk, data={"back_subject": "C"})
+    otis.assert_30x(resp)
+    assert resp.url == "/tubes/casual/C/"
+    assert proposal.upvotes.filter(pk=contributor.pk).exists()
+
+
+@pytest.mark.django_db
+def test_upvote_denied_before_the_statement_is_seen(otis):
+    # Ranked mode hides the statement until a fight starts, so there is nothing to
+    # form an opinion about yet.
+    user, _ = _verified_contributor()
+    proposal = OIMEProposalFactory.create()
+    otis.login(user)
+    resp = otis.get_20x("oime-start-fight", proposal.pk)
+    assert not resp.context["can_upvote"]
+    resp = otis.post("oime-upvote", proposal.pk)
+    assert resp.status_code == 403
+    assert proposal.upvotes.count() == 0
 
 
 @pytest.mark.django_db

--- a/tubes/tests.py
+++ b/tubes/tests.py
@@ -1070,6 +1070,28 @@ def test_casual_browse_controls_carry_settings(otis):
 
 
 @pytest.mark.django_db
+def test_casual_browse_difficulty_badges_toggle_the_filter(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    OIMEProposalFactory.create(subject="A", difficulty=2)
+    OIMEProposalFactory.create(subject="A", difficulty=4)
+    otis.login(user)
+
+    # Unfiltered, each badge links to its own difficulty, keeping the sort.
+    resp = otis.get_20x("oime-casual-browse", "A", data={"sort": "votes"})
+    assert [p.difficulty_params for p in resp.context["page_obj"]] == [
+        "sort=votes&difficulty=4",
+        "sort=votes&difficulty=2",
+    ]
+
+    # The badge of the difficulty already filtered on clears the filter instead.
+    resp = otis.get_20x("oime-casual-browse", "A", data={"difficulty": 4})
+    assert [p.difficulty_params for p in resp.context["page_obj"]] == [""]
+    otis.assert_testid(resp, "browse-difficulty-badge", count=1)
+
+
+@pytest.mark.django_db
 def test_casual_browse_marks_upvoted_problems(otis):
     user, contributor = _verified_contributor()
     contributor.casual_mode = True

--- a/tubes/tests.py
+++ b/tubes/tests.py
@@ -1092,6 +1092,30 @@ def test_casual_browse_difficulty_badges_toggle_the_filter(otis):
 
 
 @pytest.mark.django_db
+def test_casual_browse_blocks_voting_during_a_ranked_fight(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    # A fight still running keeps the solution hidden, and the vote with it.
+    running = OIMEProposalFactory.create(subject="C")
+    OIMEFightFactory.create(
+        contributor=contributor, proposal=running, status="OIME_TBD"
+    )
+    finished = OIMEProposalFactory.create(subject="C")
+    OIMEFightFactory.create(
+        contributor=contributor, proposal=finished, status="OIME_OK"
+    )
+    untouched = OIMEProposalFactory.create(subject="C")
+    otis.login(user)
+    resp = otis.get_20x("oime-casual-browse", "C")
+    assert {p.pk: p.can_upvote for p in resp.context["page_obj"]} == {
+        running.pk: False,
+        finished.pk: True,
+        untouched.pk: True,
+    }
+
+
+@pytest.mark.django_db
 def test_casual_browse_marks_upvoted_problems(otis):
     user, contributor = _verified_contributor()
     contributor.casual_mode = True
@@ -1370,6 +1394,65 @@ def test_upvote_toggles_off(otis):
     otis.login(user)
     otis.post("oime-upvote", proposal.pk)
     assert not proposal.upvotes.filter(pk=contributor.pk).exists()
+
+
+@pytest.mark.django_db
+def test_upvote_from_casual_browse_returns_to_the_same_page(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    proposal = OIMEProposalFactory.create(subject="A", difficulty=3)
+    otis.login(user)
+    resp = otis.post(
+        "oime-upvote",
+        proposal.pk,
+        data={
+            "back_subject": "A",
+            "back_params": "sort=votes&difficulty=3&page=2",
+        },
+    )
+    otis.assert_30x(resp)
+    assert resp.url == "/tubes/casual/A/?sort=votes&difficulty=3&page=2"
+    assert proposal.upvotes.filter(pk=contributor.pk).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "data",
+    [
+        # No return target at all: an ordinary vote from the problem's own page.
+        {},
+        # A forged target cannot send the voter anywhere but this browser.
+        {"back_subject": "https://evil.example.com"},
+        {"back_subject": "Z"},
+    ],
+)
+def test_upvote_falls_back_to_the_detail_page(otis, data: dict[str, str]):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    proposal = OIMEProposalFactory.create()
+    otis.login(user)
+    resp = otis.post("oime-upvote", proposal.pk, data=data)
+    otis.assert_30x(resp)
+    assert resp.url == f"/tubes/proposal/{proposal.pk}/"
+    assert proposal.upvotes.filter(pk=contributor.pk).exists()
+
+
+@pytest.mark.django_db
+def test_upvote_return_ignores_bogus_browse_params(otis):
+    user, contributor = _verified_contributor()
+    contributor.casual_mode = True
+    contributor.save()
+    proposal = OIMEProposalFactory.create(subject="G")
+    otis.login(user)
+    resp = otis.post(
+        "oime-upvote",
+        proposal.pk,
+        data={"back_subject": "G", "back_params": "difficulty=9&page=banana&sort=x"},
+    )
+    otis.assert_30x(resp)
+    assert resp.url == "/tubes/casual/G/"
 
 
 @pytest.mark.django_db

--- a/tubes/views.py
+++ b/tubes/views.py
@@ -195,6 +195,11 @@ def _get_solver_context(
 
     The proposal's author always sees everything.
 
+    Upvoting is gated on having seen the *statement*, not the solution: a casual
+    browser may vote on anything they can read, and a ranked contributor from the
+    moment they start a fight rather than only once it is finished. Voting on a
+    problem you have never opened is the only thing being prevented.
+
     An archived problem is frozen on top of all that: staff pulled it out of
     circulation, so no one starts a session on it or upvotes it any more, however
     they came to still have read access to it.
@@ -253,7 +258,7 @@ def _get_solver_context(
         "fight": fight,
         "can_see_solution": can_see_solution,
         "can_start_fight": fight is None and not revealed and not frozen,
-        "can_upvote": can_see_solution and not frozen,
+        "can_upvote": (fight is not None or revealed) and not frozen,
     }
 
 
@@ -530,15 +535,6 @@ def casual_browse(request: HttpRequest, subject: str) -> HttpResponse:
             proposal.browse_status = "new"  # type: ignore[attr-defined]
         proposal.spoiled = proposal.browse_status != "new"  # type: ignore[attr-defined]
         proposal.has_upvoted = proposal.pk in upvoted_ids  # type: ignore[attr-defined]
-        # Everything listed here is unarchived and browsed casually, so voting is
-        # open except on a problem whose ranked fight is still running: that path
-        # withholds the solution, and the vote with it, until the fight is closed.
-        proposal.can_upvote = (  # type: ignore[attr-defined]
-            proposal.author == contributor
-            or fight is None
-            or fight.is_complete
-            or proposal.pk in revealed_ids
-        )
         # Clicking a card's difficulty badge filters down to that difficulty, or
         # clears the filter when it is the one already being applied.
         proposal.difficulty_params = _browse_params(  # type: ignore[attr-defined]

--- a/tubes/views.py
+++ b/tubes/views.py
@@ -9,8 +9,9 @@ from django.core.paginator import Paginator
 from django.db import transaction
 from django.db.models import Count
 from django.db.models.query import QuerySet
-from django.http import Http404, HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse, QueryDict
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import urlencode
 from django.views.generic import CreateView, ListView, TemplateView, UpdateView
@@ -389,18 +390,44 @@ def _parse_difficulty(raw: str | None) -> int | None:
     return difficulty if difficulty in CASUAL_BROWSE_DIFFICULTIES else None
 
 
-def _browse_params(sort_by_votes: bool, difficulty: int | None) -> str:
+def _browse_params(sort_by_votes: bool, difficulty: int | None, page: int = 1) -> str:
     """The query string (no leading "?") holding the casual browser's settings.
 
-    The page number is deliberately left out: any change of sort or filter reshuffles
-    the list, so whatever page the contributor was on no longer means anything.
+    The page is left out by default: any change of sort or filter reshuffles the list,
+    so whatever page the contributor was on no longer means anything. It is only
+    passed when returning someone to the exact page they voted from.
     """
     params: dict[str, str] = {}
     if sort_by_votes:
         params["sort"] = "votes"
     if difficulty is not None:
         params["difficulty"] = str(difficulty)
+    if page > 1:
+        params["page"] = str(page)
     return urlencode(params)
+
+
+def _upvote_return_url(request: HttpRequest) -> str | None:
+    """Where a vote cast from the casual browser should land, or None if not from it.
+
+    Voting from the browser should leave the reader where they were rather than
+    bouncing them to the problem page. The target is rebuilt from the posted values
+    instead of being echoed back, so a forged form can only ever point at a subject
+    page of this browser.
+    """
+    subject = request.POST.get("back_subject", "")
+    if subject not in SUBJECT_NAMES:
+        return None
+    query = QueryDict(request.POST.get("back_params", ""))
+    try:
+        page = int(query.get("page", ""))
+    except ValueError:
+        page = 1
+    params = _browse_params(
+        query.get("sort") == "votes", _parse_difficulty(query.get("difficulty")), page
+    )
+    url = reverse("oime-casual-browse", args=[subject])
+    return f"{url}?{params}" if params else url
 
 
 def _difficulty_options(
@@ -503,6 +530,15 @@ def casual_browse(request: HttpRequest, subject: str) -> HttpResponse:
             proposal.browse_status = "new"  # type: ignore[attr-defined]
         proposal.spoiled = proposal.browse_status != "new"  # type: ignore[attr-defined]
         proposal.has_upvoted = proposal.pk in upvoted_ids  # type: ignore[attr-defined]
+        # Everything listed here is unarchived and browsed casually, so voting is
+        # open except on a problem whose ranked fight is still running: that path
+        # withholds the solution, and the vote with it, until the fight is closed.
+        proposal.can_upvote = (  # type: ignore[attr-defined]
+            proposal.author == contributor
+            or fight is None
+            or fight.is_complete
+            or proposal.pk in revealed_ids
+        )
         # Clicking a card's difficulty badge filters down to that difficulty, or
         # clears the filter when it is the one already being applied.
         proposal.difficulty_params = _browse_params(  # type: ignore[attr-defined]
@@ -525,6 +561,7 @@ def casual_browse(request: HttpRequest, subject: str) -> HttpResponse:
             "browse_params": _browse_params(sort_by_votes, difficulty),
             "sort_toggle_params": _browse_params(not sort_by_votes, difficulty),
             "difficulty_options": _difficulty_options(sort_by_votes, difficulty),
+            "back_params": _browse_params(sort_by_votes, difficulty, page_obj.number),
         },
     )
 
@@ -1025,7 +1062,9 @@ def upvote_proposal(request: HttpRequest, pk: int) -> HttpResponse:
     else:
         proposal.upvotes.add(contributor)
 
-    return redirect("oime-proposal-detail", pk)
+    return redirect(
+        _upvote_return_url(request) or reverse("oime-proposal-detail", args=[pk])
+    )
 
 
 @verified_required

--- a/tubes/views.py
+++ b/tubes/views.py
@@ -503,6 +503,12 @@ def casual_browse(request: HttpRequest, subject: str) -> HttpResponse:
             proposal.browse_status = "new"  # type: ignore[attr-defined]
         proposal.spoiled = proposal.browse_status != "new"  # type: ignore[attr-defined]
         proposal.has_upvoted = proposal.pk in upvoted_ids  # type: ignore[attr-defined]
+        # Clicking a card's difficulty badge filters down to that difficulty, or
+        # clears the filter when it is the one already being applied.
+        proposal.difficulty_params = _browse_params(  # type: ignore[attr-defined]
+            sort_by_votes,
+            None if proposal.difficulty == difficulty else proposal.difficulty,
+        )
     page_obj.object_list = page_proposals
 
     return render(


### PR DESCRIPTION
Follow-up to #566, from prod feedback on the casual per-subject browser.

## Describe what kind of changes you made here

A mix of a layout fix, an enhancement, and one small behaviour change.

**Layout fix — the card header badges.** They carried `px-2 py-2`, which made
them taller than the plain title text beside them; combined with
`align-items-start` the two sat on different baselines. The row is now
`align-items-center`, the badges use the default badge padding, and the gap
between them is `gap-1` so they take less width next to a long title. The
difficulty badge also moved ahead of the heart, matching the order on the
problem's own page.

**Enhancement — the difficulty badge filters.** Clicking one filters the
browser to that difficulty, or clears the filter if it is the one already
applied. While a filter is on the badges render solid primary, the same
treatment the toolbar buttons use. The per-row target is built in the view,
so these are plain links and nothing changes about how the filtering works.

**Enhancement — voting from the card.** The heart showed vote state but did
nothing, while on the problem's own page the heart *is* the vote button. It
is one here too now, so triaging a subject can be read-statement, heart,
scroll without leaving the page. A vote returns to the page it was cast from,
including sort, difficulty and page number; the target is rebuilt server-side
from a posted subject code plus re-parsed settings rather than echoed back, so
a forged form can only ever point at a subject page of this browser, and
anything unrecognized falls back to the problem page where the detail-page
button still lands.

**Behaviour change — what upvoting requires.** `can_upvote` was defined as
`can_see_solution`, one flag answering both "may I read the solution" and "may
I rate this". That left a ranked contributor unable to vote during a running
fight, with the statement open in front of them, while a casual browser four
lines up could vote having read only the statement and never the solution. It
is now gated on having seen the *statement*: in ranked mode from the moment a
fight starts rather than only once it finishes. Voting on a problem you have
never opened stays blocked, which is the case worth preventing, and archived
problems stay frozen.

Worth flagging that this is only observable through the casual browser —
`proposal_detail` redirects a ranked contributor mid-fight to the fight page
and one with no fight to the start screen, and neither renders a heart. The
browse cards were the only place the old rule bit. Landing copy updated to
match.

## Testing

`make fmt`, `make check` (pyright clean) and 127 tubes tests pass. New
coverage for the badge filter toggle, the vote round-trip and its return
target, forged and malformed return params, voting during a running fight,
and voting before a statement has been seen.


---
_Generated by [Claude Code](https://claude.ai/code/session_014zqjcRQjq1aiSwYjcBEcZ1)_