### PR TITLE
feat(tubes): rework the revealed-solution presentation

### DIFF
--- a/otisweb/static/css/otis.css
+++ b/otisweb/static/css/otis.css
@@ -421,6 +421,15 @@ img.emoji {
   );
 }
 
+/* OIME solution preview. Its summary is styled as a button, so drop the
+   disclosure triangle a browser would otherwise draw beside the label. */
+.oime-solution-preview > summary {
+  list-style: none;
+}
+.oime-solution-preview > summary::-webkit-details-marker {
+  display: none;
+}
+
 /* OIME proposal table collapse toggle */
 .oime-table-toggle::before {
   content: "▾ ";

--- a/tubes/templates/tubes/components/proposal_stats.html
+++ b/tubes/templates/tubes/components/proposal_stats.html
@@ -1,6 +1,16 @@
 <table class="table table-sm w-auto mb-2">
   <tbody>
     <tr>
+      <th class="pe-4">Your result</th>
+      <td data-testid="stats-your-result">
+        {% if fight.is_complete %}
+          {% include "tubes/components/fight_verdict.html" %}
+        {% else %}
+          —
+        {% endif %}
+      </td>
+    </tr>
+    <tr>
       <th class="pe-4">Fastest clean solve</th>
       <td>
         {% if stats.fastest_clean %}

--- a/tubes/templates/tubes/proposal_detail.html
+++ b/tubes/templates/tubes/proposal_detail.html
@@ -75,7 +75,7 @@
   <hr />
   {# ---- Casual mode: self-check or reveal the solution on demand ---- #}
   {% if not can_see_solution %}
-    <h3>Solution</h3>
+    <h2>Solution</h2>
     <form method="post" action="{% url "oime-reveal" proposal.pk %}">
       {% csrf_token %}
       <button type="submit" class="btn btn-primary btn-sm">Reveal solution</button>
@@ -102,66 +102,64 @@
   {# ---- Answer + solution ---- #}
   {% if can_see_solution %}
     <h2 id="oime-answer-section">Answer: {{ proposal.answer }}</h2>
-    {% comment %}
-      The disclosure element is a flex item, so it sits beside the download button
-      while closed and takes a line of its own once the solution unfolds. Using it
-      keeps the preview a toggle without any JavaScript.
-    {% endcomment %}
-    <div class="d-flex flex-wrap align-items-start gap-2 mb-4">
+    <p class="mb-2">
       <a href="{% url "oime-proposal-solution-tex" proposal.pk %}"
          class="btn btn-primary"
          target="_blank"
          rel="noopener"
          data-testid="solution-tex-link">Download solution (TeX)</a>
-      <details data-testid="solution-preview">
-        <summary class="btn btn-secondary">Preview with MathJax</summary>
-        <p class="small text-muted mt-3 mb-2">
-          MathJax ≠ LaTeX, so this convenience preview only supports some basic features.
-        </p>
-        <div class="math-content">{{ proposal.solution }}</div>
-      </details>
-    </div>
+    </p>
+    {% comment %}
+      A plain disclosure element, so the toggle needs no JavaScript. It sits on a
+      line of its own rather than beside the download button, so that unfolding
+      the preview never moves the button that unfolds it.
+    {% endcomment %}
+    <details class="oime-solution-preview mb-4" data-testid="solution-preview">
+      <summary class="btn btn-secondary">Preview with MathJax</summary>
+      <p class="small text-muted mt-3 mb-2">
+        MathJax ≠ LaTeX, so this convenience preview only supports some basic features.
+      </p>
+      <div class="math-content">{{ proposal.solution }}</div>
+    </details>
   {% endif %}
   {# ---- Discussion (only once the solution is visible) ---- #}
   {% if can_see_solution %}
     <h2>Discussion</h2>
     {% if comments %}
       {% for comment in comments %}
-        <div class="card mb-2">
-          <div class="card-body">
-            <p class="card-text">{{ comment.content|linebreaks }}</p>
-            <small class="text-muted">
-              {{ comment.author }}
-              {% if comment.author_id == proposal.author_id %}
-                <span class="badge bg-secondary" title="This commenter wrote the problem">Author</span>
+        {% comment %}
+          Plain prose, not a card: the byline hangs off the bottom of the comment
+          it belongs to, and the gap to the next comment is the wider one.
+        {% endcomment %}
+        <div class="mb-4">
+          {{ comment.content|linebreaks }}
+          <p class="small text-muted mb-0">
+            {{ comment.author }}
+            {% if comment.author_id == proposal.author_id %}
+              <span class="badge bg-secondary" title="This commenter wrote the problem">Author</span>
+            {% endif %}
+            · {{ comment.created_at|date:"Y-m-d H:i" }}
+            {% if comment.is_edited %}
+              <span data-testid="comment-edited">(edited {{ comment.updated_at|date:"Y-m-d H:i" }})</span>
+            {% endif %}
+            {% if not proposal.archived %}
+              {% if comment.author == contributor or request.user.is_staff %}
+                · <a href="{% url "oime-comment-edit" comment.pk %}">Edit</a>
               {% endif %}
-              · {{ comment.created_at|date:"Y-m-d H:i" }}
-              {% if comment.is_edited %}
-                <span data-testid="comment-edited">(edited {{ comment.updated_at|date:"Y-m-d H:i" }})</span>
-              {% endif %}
-              {% if not proposal.archived %}
-                {% if comment.author == contributor or request.user.is_staff %}
-                  · <a href="{% url "oime-comment-edit" comment.pk %}">Edit</a>
-                {% endif %}
-              {% endif %}
-            </small>
-          </div>
+            {% endif %}
+          </p>
         </div>
       {% endfor %}
     {% else %}
       <p class="text-muted">No comments yet.</p>
     {% endif %}
     {% if can_comment %}
-      <div class="card mt-3" data-testid="comment-form">
-        <div class="card-header">Add a comment</div>
-        <div class="card-body">
-          <form method="post">
-            {% csrf_token %}
-            {{ comment_form.content }}
-            <button type="submit" name="submit_comment" class="btn btn-primary mt-2">Post Comment</button>
-          </form>
-        </div>
-      </div>
+      <h3>Add a comment</h3>
+      <form method="post" data-testid="comment-form">
+        {% csrf_token %}
+        {{ comment_form.content }}
+        <button type="submit" name="submit_comment" class="btn btn-primary mt-2">Post Comment</button>
+      </form>
     {% endif %}
   {% endif %}
 {% endblock layout-content %}

--- a/tubes/templates/tubes/proposal_detail.html
+++ b/tubes/templates/tubes/proposal_detail.html
@@ -101,7 +101,7 @@
   {% endif %}
   {# ---- Answer + solution ---- #}
   {% if can_see_solution %}
-    <h3 id="oime-answer-section">Answer: {{ proposal.answer }}</h3>
+    <h2 id="oime-answer-section">Answer: {{ proposal.answer }}</h2>
     {% comment %}
       The disclosure element is a flex item, so it sits beside the download button
       while closed and takes a line of its own once the solution unfolds. Using it
@@ -124,7 +124,7 @@
   {% endif %}
   {# ---- Discussion (only once the solution is visible) ---- #}
   {% if can_see_solution %}
-    <h3>Discussion</h3>
+    <h2>Discussion</h2>
     {% if comments %}
       {% for comment in comments %}
         <div class="card mb-2">

--- a/tubes/templates/tubes/proposal_detail.html
+++ b/tubes/templates/tubes/proposal_detail.html
@@ -109,16 +109,9 @@
          rel="noopener"
          data-testid="solution-tex-link">Download solution (TeX)</a>
     </p>
-    {% comment %}
-      A plain disclosure element, so the toggle needs no JavaScript. It sits on a
-      line of its own rather than beside the download button, so that unfolding
-      the preview never moves the button that unfolds it.
-    {% endcomment %}
     <details class="oime-solution-preview mb-4" data-testid="solution-preview">
       <summary class="btn btn-secondary">Preview solution with MathJax</summary>
-      <p class="small text-muted mt-3 mb-2">
-        MathJax ≠ LaTeX, so this convenience preview only supports some basic features.
-      </p>
+      <p class="small text-danger mt-3 mb-2">MathJax ≠ LaTeX. This convenience preview only supports basic math.</p>
       <div class="math-content">{{ proposal.solution }}</div>
     </details>
   {% endif %}

--- a/tubes/templates/tubes/proposal_detail.html
+++ b/tubes/templates/tubes/proposal_detail.html
@@ -28,6 +28,23 @@
             </button>
           </form>
         {% endif %}
+        {# Staff archive toggle rides along with the badges to save vertical space. #}
+        {% if request.user.is_superuser %}
+          <form method="post"
+                action="{% url "oime-proposal-archive" proposal.pk %}"
+                class="d-inline">
+            {% csrf_token %}
+            <button type="submit"
+                    class="btn btn-outline-secondary btn-sm"
+                    data-testid="proposal-archive-toggle">
+              {% if proposal.archived %}
+                Unarchive
+              {% else %}
+                Archive
+              {% endif %}
+            </button>
+          </form>
+        {% endif %}
       </div>
       <p class="text-muted">
         Written by {{ proposal.credit_display }}
@@ -50,46 +67,12 @@
       <div class="math-content">{{ proposal.statement }}</div>
     </div>
   </div>
-  {# ---- Staff-only archive toggle ---- #}
-  {% if request.user.is_superuser %}
-    <form method="post"
-          action="{% url "oime-proposal-archive" proposal.pk %}"
-          class="mb-4">
-      {% csrf_token %}
-      <button type="submit"
-              class="btn btn-outline-secondary btn-sm"
-              data-testid="proposal-archive-toggle">
-        {% if proposal.archived %}
-          Unarchive
-        {% else %}
-          Archive
-        {% endif %}
-      </button>
-    </form>
-  {% endif %}
   {# ---- Testsolve stats summary ---- #}
   {% include "tubes/components/proposal_stats.html" %}
   <p class="mb-2">
     <a href="{% url "oime-proposal-results" proposal.pk %}">View full statistics →</a>
   </p>
   <hr />
-  <p class="small text-muted mb-4">
-    {% if is_author %}
-      You wrote this problem, so you can see the solution.
-    {% elif fight.status == "OIME_OK" %}
-      You solved this problem in {{ fight.time_display }}
-      (with {{ fight.wrong_answers }} incorrect answer{{ fight.wrong_answers|pluralize }})
-      on {{ fight.submitted_at|date:"F j, Y" }}.
-    {% elif fight.status == "OIME_FAIL" %}
-      You gave up on this problem on {{ fight.submitted_at|date:"F j, Y" }}.
-    {% elif fight.status == "OIME_TLE" %}
-      You ran out of time on this problem on {{ fight.submitted_at|date:"F j, Y" }}.
-    {% elif fight.status == "OIME_ALE" %}
-      You used up all your answer attempts on this problem on {{ fight.submitted_at|date:"F j, Y" }}.
-    {% elif can_see_solution %}
-      You revealed the solution to this problem.
-    {% endif %}
-  </p>
   {# ---- Casual mode: self-check or reveal the solution on demand ---- #}
   {% if not can_see_solution %}
     <h3>Solution</h3>
@@ -116,28 +99,27 @@
       <small class="oime-check-result ms-1"></small>
     </div>
   {% endif %}
-  {# ---- Show attempt result + answer + solution ---- #}
+  {# ---- Answer + solution ---- #}
   {% if can_see_solution %}
-    {% if fight %}
-      {% if fight.status == "OIME_OK" %}
-        <div class="alert alert-success">
-          Solved in {{ fight.time_display }} with {{ fight.wrong_answers }} wrong answer{{ fight.wrong_answers|pluralize }}.
-        </div>
-      {% elif fight.status == "OIME_FAIL" %}
-        <div class="alert alert-secondary" data-testid="fight-gave-up">You gave up on this problem.</div>
-      {% elif fight.status == "OIME_TLE" %}
-        <div class="alert alert-danger">Time limit exceeded.</div>
-      {% elif fight.status == "OIME_ALE" %}
-        <div class="alert alert-danger">
-          Answer limit exceeded ({{ fight.wrong_answers }} wrong answer{{ fight.wrong_answers|pluralize }}).
-        </div>
-      {% endif %}
-    {% endif %}
-    <div class="card mb-4" id="oime-answer-section">
-      <div class="card-header fw-bold">Answer: {{ proposal.answer }}</div>
-      <div class="card-body">
+    <h3 id="oime-answer-section">Answer: {{ proposal.answer }}</h3>
+    {% comment %}
+      The disclosure element is a flex item, so it sits beside the download button
+      while closed and takes a line of its own once the solution unfolds. Using it
+      keeps the preview a toggle without any JavaScript.
+    {% endcomment %}
+    <div class="d-flex flex-wrap align-items-start gap-2 mb-4">
+      <a href="{% url "oime-proposal-solution-tex" proposal.pk %}"
+         class="btn btn-primary"
+         target="_blank"
+         rel="noopener"
+         data-testid="solution-tex-link">Download solution (TeX)</a>
+      <details data-testid="solution-preview">
+        <summary class="btn btn-secondary">Preview with MathJax</summary>
+        <p class="small text-muted mt-3 mb-2">
+          MathJax ≠ LaTeX, so this convenience preview only supports some basic features.
+        </p>
         <div class="math-content">{{ proposal.solution }}</div>
-      </div>
+      </details>
     </div>
   {% endif %}
   {# ---- Discussion (only once the solution is visible) ---- #}

--- a/tubes/templates/tubes/proposal_detail.html
+++ b/tubes/templates/tubes/proposal_detail.html
@@ -115,7 +115,7 @@
       the preview never moves the button that unfolds it.
     {% endcomment %}
     <details class="oime-solution-preview mb-4" data-testid="solution-preview">
-      <summary class="btn btn-secondary">Preview with MathJax</summary>
+      <summary class="btn btn-secondary">Preview solution with MathJax</summary>
       <p class="small text-muted mt-3 mb-2">
         MathJax ≠ LaTeX, so this convenience preview only supports some basic features.
       </p>

--- a/tubes/tests.py
+++ b/tubes/tests.py
@@ -749,6 +749,67 @@ def test_ranked_escape_hatch_reveal(otis):
 
 
 @pytest.mark.django_db
+def test_solution_offered_as_tex_download_and_mathjax_preview(otis):
+    user, contributor = _verified_contributor()
+    proposal = OIMEProposalFactory.create()
+    OIMEFightFactory.create(
+        contributor=contributor, proposal=proposal, status="OIME_OK"
+    )
+    otis.login(user)
+    resp = otis.get_20x("oime-proposal-detail", proposal.pk)
+    otis.assert_testid(resp, "solution-tex-link")
+    otis.assert_testid(resp, "solution-preview")
+    otis.assert_has(resp, otis.url("oime-proposal-solution-tex", proposal.pk))
+
+
+@pytest.mark.django_db
+def test_solution_tex_download(otis):
+    user, contributor = _verified_contributor()
+    proposal = OIMEProposalFactory.create(
+        answer=42,
+        statement="Compute $1+1$.",
+        solution="Clearly $1+1=2$.",
+    )
+    OIMEFightFactory.create(
+        contributor=contributor, proposal=proposal, status="OIME_OK"
+    )
+    otis.login(user)
+    # The response body is the product here, so the bytes really are the contract.
+    resp = otis.get_20x("oime-proposal-solution-tex", proposal.pk)
+    assert resp.headers["Content-Disposition"] == (
+        f'attachment; filename="oime-{proposal.label}.tex"'
+    )
+    otis.assert_has(resp, "Compute $1+1$.")
+    otis.assert_has(resp, "\\textbf{Answer.} 42")
+    otis.assert_has(resp, "Clearly $1+1=2$.")
+
+
+@pytest.mark.django_db
+def test_solution_tex_denied_before_solution_is_visible(otis):
+    user, contributor = _verified_contributor()
+    proposal = OIMEProposalFactory.create(solution="Secret solution.")
+    otis.login(user)
+    # Ranked, never fought: the answer and solution are still under lock.
+    resp = otis.get_40x("oime-proposal-solution-tex", proposal.pk)
+    otis.assert_not_has(resp, "Secret solution.")
+    # An active fight is no better; the file carries the answer.
+    OIMEFightFactory.create(
+        contributor=contributor, proposal=proposal, status="OIME_TBD"
+    )
+    resp = otis.get_40x("oime-proposal-solution-tex", proposal.pk)
+    otis.assert_not_has(resp, "Secret solution.")
+
+
+@pytest.mark.django_db
+def test_solution_tex_denied_on_archived_problem(otis):
+    user, _ = _verified_contributor()
+    _, other = _verified_contributor("bob")
+    proposal = OIMEProposalFactory.create(author=other, archived=True)
+    otis.login(user)
+    otis.get_40x("oime-proposal-solution-tex", proposal.pk)
+
+
+@pytest.mark.django_db
 def test_cannot_reveal_during_active_fight(otis):
     user, contributor = _verified_contributor()
     proposal = OIMEProposalFactory.create()
@@ -1919,7 +1980,7 @@ def test_expired_give_up_does_not_count_against_rate_limit(otis):
 
 
 @pytest.mark.django_db
-def test_detail_shows_gave_up_alert_box(otis):
+def test_detail_stats_show_own_verdict(otis):
     user, contributor = _verified_contributor()
     proposal = OIMEProposalFactory.create()
     OIMEFightFactory.create(
@@ -1927,7 +1988,33 @@ def test_detail_shows_gave_up_alert_box(otis):
     )
     otis.login(user)
     resp = otis.get_20x("oime-proposal-detail", proposal.pk)
-    otis.assert_testid(resp, "fight-gave-up")
+    otis.assert_testid(resp, "stats-your-result")
+    otis.assert_testid(resp, "verdict-gave-up")
+
+
+@pytest.mark.django_db
+def test_detail_stats_show_dash_when_never_fought(otis):
+    """An author never fights their own problem, so their verdict row stays empty."""
+    user, contributor = _verified_contributor()
+    proposal = OIMEProposalFactory.create(author=contributor)
+    otis.login(user)
+    resp = otis.get_20x("oime-proposal-detail", proposal.pk)
+    otis.assert_testid(resp, "stats-your-result")
+    otis.assert_no_testid(resp, "verdict-gave-up")
+    otis.assert_no_testid(resp, "verdict-solved")
+
+
+@pytest.mark.django_db
+def test_results_stats_show_own_verdict(otis):
+    user, contributor = _verified_contributor()
+    proposal = OIMEProposalFactory.create()
+    OIMEFightFactory.create(
+        contributor=contributor, proposal=proposal, status="OIME_OK"
+    )
+    otis.login(user)
+    resp = otis.get_20x("oime-proposal-results", proposal.pk)
+    assert resp.context["fight"].status == "OIME_OK"
+    otis.assert_testid(resp, "stats-your-result")
 
 
 # ---------------------------------------------------------------------------

--- a/tubes/tests.py
+++ b/tubes/tests.py
@@ -780,7 +780,7 @@ def test_solution_tex_download(otis):
         f'attachment; filename="oime-{proposal.label}.tex"'
     )
     otis.assert_has(resp, "Compute $1+1$.")
-    otis.assert_has(resp, "\\textbf{Answer.} 42")
+    otis.assert_has(resp, "42")
     otis.assert_has(resp, "Clearly $1+1=2$.")
 
 

--- a/tubes/urls.py
+++ b/tubes/urls.py
@@ -18,6 +18,11 @@ urlpatterns = [
     path(r"proposal/<int:pk>/upvote/", views.upvote_proposal, name="oime-upvote"),
     path(r"proposal/<int:pk>/reveal/", views.reveal_solution, name="oime-reveal"),
     path(
+        r"proposal/<int:pk>/solution.tex",
+        views.proposal_solution_tex,
+        name="oime-proposal-solution-tex",
+    ),
+    path(
         r"proposal/<int:pk>/archive/",
         views.toggle_archive,
         name="oime-proposal-archive",

--- a/tubes/views.py
+++ b/tubes/views.py
@@ -941,17 +941,23 @@ def proposal_solution_tex(request: HttpRequest, pk: int) -> HttpResponse:
     written_on = f"{timezone.localtime(proposal.created_at):%Y-%m-%d}"
     content = "\n".join(
         (
-            f"% OIME {proposal.label}: {proposal.title}",
-            f"% Written by {proposal.credit_display} on {written_on}",
+            r"\documentclass[11pt]{article}",
+            r"\usepackage{amsmath,amsthm,amssymb}",
+            r"\begin{document}",
+            f"\\title{{{proposal.label}: {proposal.title}}}",
+            f"\\author{{{proposal.credit_display}}}",
+            f"\\date{{{written_on}}}",
+            r"\maketitle",
             "",
-            "\\textbf{Problem.}",
+            r"\section*{Problem}",
             proposal.statement,
             "",
-            f"\\textbf{{Answer.}} {proposal.answer}",
+            f"\\section*{{Answer}}\n{proposal.answer}",
             "",
-            "\\textbf{Solution.}",
+            r"\section*{Solution}",
             proposal.solution,
             "",
+            r"\end{document}",
         )
     )
     filename = f"oime-{proposal.label}.tex"

--- a/tubes/views.py
+++ b/tubes/views.py
@@ -918,6 +918,51 @@ def proposal_detail(request: HttpRequest, pk: int) -> HttpResponse:
 
 
 @verified_required
+def proposal_solution_tex(request: HttpRequest, pk: int) -> HttpResponse:
+    """Download a problem's answer and solution as a LaTeX file.
+
+    The on-page preview is typeset by MathJax, which understands only a fraction of
+    LaTeX, so the source is what a contributor actually wants once a solution uses
+    anything beyond basic math mode. Gated exactly like the solution itself: the
+    answer is in the file, so anyone who cannot see the solution on the detail page
+    must not be able to fetch it here either.
+    """
+    proposal = get_object_or_404(OIMEProposal, pk=pk)
+    contributor = _get_contributor(request)
+    if contributor is None:
+        return redirect("oime-setup")
+
+    _deny_if_hidden(request, proposal, contributor)
+
+    ctx = _get_solver_context(contributor, proposal)
+    if not ctx["can_see_solution"]:
+        raise PermissionDenied("You cannot see the solution to this problem yet.")
+
+    written_on = f"{timezone.localtime(proposal.created_at):%Y-%m-%d}"
+    content = "\n".join(
+        (
+            f"% OIME {proposal.label}: {proposal.title}",
+            f"% Written by {proposal.credit_display} on {written_on}",
+            "",
+            "\\textbf{Problem.}",
+            proposal.statement,
+            "",
+            f"\\textbf{{Answer.}} {proposal.answer}",
+            "",
+            "\\textbf{Solution.}",
+            proposal.solution,
+            "",
+        )
+    )
+    filename = f"oime-{proposal.label}.tex"
+    return HttpResponse(
+        content=content,
+        content_type="application/x-tex; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@verified_required
 def proposal_fight(request: HttpRequest, pk: int) -> HttpResponse:
     """Timed solving screen for a ranked contributor with an active attempt."""
     proposal = get_object_or_404(OIMEProposal, pk=pk)
@@ -1185,6 +1230,8 @@ def proposal_results(request: HttpRequest, pk: int) -> HttpResponse:
             "proposal": proposal,
             "contributor": contributor,
             "fights": fights,
+            # The stats table leads with this viewer's own verdict on the problem.
+            "fight": ctx["fight"],
             "stats": _proposal_stats(proposal),
         },
     )


### PR DESCRIPTION
- allow downloading TeX directly, since mathjax is incomplete preview
- move archive button
- "Your result" is more concise than whatever there was before
